### PR TITLE
Check if deferred bindings is enabled in base ext

### DIFF
--- a/azure-functions-extension-base/azure/functions/extension/base/__init__.py
+++ b/azure-functions-extension-base/azure/functions/extension/base/__init__.py
@@ -7,7 +7,8 @@ from .meta import (
     _BaseConverter,
     InConverter,
     OutConverter,
-    get_binding_registry
+    get_binding_registry,
+    check_deferred_bindings_enabled
 )
 from .sdkType import SdkType
 from .web import (
@@ -28,6 +29,7 @@ __all__ = [
     'OutConverter',
     'SdkType',
     'get_binding_registry',
+    'check_deferred_bindings_enabled',
     'ModuleTrackerMeta',
     'RequestTrackerMeta',
     'ResponseTrackerMeta',

--- a/azure-functions-extension-base/azure/functions/extension/base/meta.py
+++ b/azure-functions-extension-base/azure/functions/extension/base/meta.py
@@ -10,7 +10,6 @@ from . import sdkType
 
 from typing import Any, Dict, List, Optional, Mapping, Union, Tuple
 
-BINDING_REGISTRY_SET = False
 
 class Datum:
     def __init__(self, value: Any, type: Optional[str]):
@@ -182,11 +181,9 @@ class OutConverter(_BaseConverter, binding=None):
 
 
 def get_binding_registry():
-    global BINDING_REGISTRY_SET
-    BINDING_REGISTRY_SET = True
     return _ConverterMeta
 
 
-def check_deferred_bindings_enabled(cls, pytype: type) -> bool:
-    return (BINDING_REGISTRY_SET
+def check_deferred_bindings_enabled(cls, sdk_binding_registry: _ConverterMeta, pytype: type) -> bool:
+    return (sdk_binding_registry is not None
             and _ConverterMeta.check_supported_type(pytype))

--- a/azure-functions-extension-base/azure/functions/extension/base/meta.py
+++ b/azure-functions-extension-base/azure/functions/extension/base/meta.py
@@ -10,6 +10,7 @@ from . import sdkType
 
 from typing import Any, Dict, List, Optional, Mapping, Union, Tuple
 
+BINDING_REGISTRY_SET = False
 
 class Datum:
     def __init__(self, value: Any, type: Optional[str]):
@@ -181,4 +182,11 @@ class OutConverter(_BaseConverter, binding=None):
 
 
 def get_binding_registry():
+    global BINDING_REGISTRY_SET
+    BINDING_REGISTRY_SET = True
     return _ConverterMeta
+
+
+def check_deferred_bindings_enabled(cls, pytype: type) -> bool:
+    return (BINDING_REGISTRY_SET
+            and _ConverterMeta.check_supported_type(pytype))


### PR DESCRIPTION
Adds a method in the base extension that will replace the following worker check.
```
if (SDK_BINDING_REGISTRY is not None
            and SDK_BINDING_REGISTRY.check_supported_type(pytype)):
```

Instead, this check will look like:
```
if check_deferred_bindings_enabled(sdk_binding_registry=SDK_BINDING_REGISTRY, pytype=pytype):
```