### PR TITLE
feat: Adding deferred bindings logs

### DIFF
--- a/azure-functions-extension-base/azure/functions/extension/base/meta.py
+++ b/azure-functions-extension-base/azure/functions/extension/base/meta.py
@@ -83,7 +83,7 @@ class _ConverterMeta(abc.ABCMeta):
         return cls._bindings.get(binding_name)
 
     @classmethod
-    def get_raw_bindings(cls, indexed_function, input_types) -> List[str]:
+    def get_raw_bindings(cls, indexed_function, input_types):
         return utils.get_raw_bindings(indexed_function, input_types)
 
     @classmethod

--- a/azure-functions-extension-base/azure/functions/extension/base/utils.py
+++ b/azure-functions-extension-base/azure/functions/extension/base/utils.py
@@ -250,11 +250,6 @@ def get_raw_bindings(indexed_function, input_types):
     bindings_logs = {}
     for b in indexed_function._bindings:
         dict_repr, logs = Binding.get_dict_repr(b, input_types)
-        binding_dict_repr.append(json.dumps(dict_repr,  cls=StringifyEnumJsonEncoder))
+        binding_dict_repr.append(json.dumps(dict_repr, cls=StringifyEnumJsonEncoder))
         bindings_logs.update(logs)
     return binding_dict_repr, bindings_logs
-
-    # return [
-    #     json.dumps(Binding.get_dict_repr(b, input_types), cls=StringifyEnumJsonEncoder)
-    #     for b in indexed_function._bindings
-    # ]

--- a/azure-functions-extension-base/azure/functions/extension/base/utils.py
+++ b/azure-functions-extension-base/azure/functions/extension/base/utils.py
@@ -172,7 +172,7 @@ class Binding(ABC):
         ((binding type, pytype), deferred bindings enabled)
         """
         params = list(dict.fromkeys(getattr(binding, "init_params", [])))
-        binding_logs = {}
+        binding_info = {}
         for p in params:
             if p not in Binding.EXCLUDED_INIT_PARAMS:
                 binding._dict[to_camel_case(p)] = getattr(binding, p, None)
@@ -191,13 +191,13 @@ class Binding(ABC):
             and meta._ConverterMeta.check_supported_type(pytype)
         ):
             binding._dict["properties"] = {"SupportsDeferredBinding": True}
-            binding_logs = {binding.name: (pytype, "True")}
+            binding_info = {binding.name: {pytype: "True"}}
         # if it isn't, we set the flag to false
         else:
             binding._dict["properties"] = {"SupportsDeferredBinding": False}
-            binding_logs = {binding.name: (pytype, "False")}
+            binding_info = {binding.name: {pytype: "False"}}
 
-        return binding._dict, binding_logs
+        return binding._dict, binding_info
 
 
 def to_camel_case(snake_case_str: str):

--- a/azure-functions-extension-base/tests/test_meta.py
+++ b/azure-functions-extension-base/tests/test_meta.py
@@ -146,7 +146,7 @@ class TestMeta(unittest.TestCase):
             _bindings = {}
             _trigger = None
 
-        self.assertEqual(registry.get_raw_bindings(MockIndexedFunction, []), [])
+        self.assertEqual(registry.get_raw_bindings(MockIndexedFunction, []), ([], {}))
 
         self.assertFalse(registry.check_supported_type(None))
         self.assertFalse(registry.check_supported_type("hello"))

--- a/azure-functions-extension-base/tests/test_utils.py
+++ b/azure-functions-extension-base/tests/test_utils.py
@@ -56,7 +56,8 @@ class TestUtils(unittest.TestCase):
         # Create test indexed_function
         mock_indexed_functions = MockFunction(bindings=[mock_blob])
 
-        dict_repr = utils.get_raw_bindings(mock_indexed_functions, mock_input_types)
+        dict_repr = utils.get_raw_bindings(mock_indexed_functions,
+                                                 mock_input_types)
         self.assertEqual(
             dict_repr,
             [
@@ -96,6 +97,42 @@ class TestUtils(unittest.TestCase):
                 '"properties": '
                 '{"SupportsDeferredBinding": false}}'
             ],
+        )
+
+    def test_get_dict_repr_binding_name_none(self):
+        # Create mock blob
+        meta._ConverterMeta._bindings = {"blob"}
+
+        # Create test binding
+        mock_blob = utils.Binding(
+            name="blob",
+            direction=utils.BindingDirection.IN,
+            data_type=None,
+            type="blob",
+        )
+
+        mock_http = utils.Binding(
+            name="$return",
+            direction=utils.BindingDirection.OUT,
+            data_type=None,
+            type="httpResponse",
+        )
+
+        # Create test input_types dict
+        mock_input_types = {
+            "blob": MockParamTypeInfo(binding_name="blobTrigger", pytype=bytes)
+        }
+
+        # Create test indexed_function
+        mock_indexed_functions = MockFunction(bindings=[mock_blob, mock_http])
+
+        dict_repr = utils.get_raw_bindings(mock_indexed_functions, mock_input_types)
+        self.assertEqual(
+            dict_repr,
+            ['{"direction": "IN", "dataType": null, "type": "blob", '
+             '"properties": {"SupportsDeferredBinding": false}}',
+             '{"direction": "OUT", "dataType": null, "type": "httpResponse", '
+             '"properties": {"SupportsDeferredBinding": false}}'],
         )
 
     def test_get_dict_repr_init_params(self):

--- a/azure-functions-extension-base/tests/test_utils.py
+++ b/azure-functions-extension-base/tests/test_utils.py
@@ -69,7 +69,7 @@ class TestUtils(unittest.TestCase):
             ],
         )
 
-        self.assertEqual(logs, {"client": (sdkType.SdkType, "True")})
+        self.assertEqual(logs, {"client": {sdkType.SdkType: "True"}})
 
     def test_get_dict_repr_non_sdk(self):
         # Create mock blob
@@ -103,7 +103,7 @@ class TestUtils(unittest.TestCase):
                 '{"SupportsDeferredBinding": false}}'
             ],
         )
-        self.assertEqual(logs, {"blob": (bytes, "False")})
+        self.assertEqual(logs, {"blob": {bytes: "False"}})
 
     def test_get_dict_repr_binding_name_none(self):
         # Create mock blob
@@ -144,7 +144,7 @@ class TestUtils(unittest.TestCase):
                 '"properties": {"SupportsDeferredBinding": false}}',
             ],
         )
-        self.assertEqual(logs, {"$return": (None, "False"), "blob": (bytes, "False")})
+        self.assertEqual(logs, {"$return": {None: "False"}, "blob": {bytes: "False"}})
 
     def test_get_dict_repr_init_params(self):
         # Create mock blob
@@ -181,7 +181,7 @@ class TestUtils(unittest.TestCase):
             ],
         )
 
-        self.assertEqual(logs, {"client": (sdkType.SdkType, "True")})
+        self.assertEqual(logs, {"client": {sdkType.SdkType: "True"}})
 
     def test_binding_data_type(self):
         mock_blob = utils.Binding(

--- a/azure-functions-extension-base/tests/test_utils.py
+++ b/azure-functions-extension-base/tests/test_utils.py
@@ -56,8 +56,9 @@ class TestUtils(unittest.TestCase):
         # Create test indexed_function
         mock_indexed_functions = MockFunction(bindings=[mock_blob])
 
-        dict_repr = utils.get_raw_bindings(mock_indexed_functions,
-                                                 mock_input_types)
+        dict_repr, logs = utils.get_raw_bindings(
+            mock_indexed_functions, mock_input_types
+        )
         self.assertEqual(
             dict_repr,
             [
@@ -67,6 +68,8 @@ class TestUtils(unittest.TestCase):
                 '{"SupportsDeferredBinding": true}}'
             ],
         )
+
+        self.assertEqual(logs, {"client": (sdkType.SdkType, "True")})
 
     def test_get_dict_repr_non_sdk(self):
         # Create mock blob
@@ -88,7 +91,9 @@ class TestUtils(unittest.TestCase):
         # Create test indexed_function
         mock_indexed_functions = MockFunction(bindings=[mock_blob])
 
-        dict_repr = utils.get_raw_bindings(mock_indexed_functions, mock_input_types)
+        dict_repr, logs = utils.get_raw_bindings(
+            mock_indexed_functions, mock_input_types
+        )
         self.assertEqual(
             dict_repr,
             [
@@ -98,6 +103,7 @@ class TestUtils(unittest.TestCase):
                 '{"SupportsDeferredBinding": false}}'
             ],
         )
+        self.assertEqual(logs, {"blob": (bytes, "False")})
 
     def test_get_dict_repr_binding_name_none(self):
         # Create mock blob
@@ -126,14 +132,19 @@ class TestUtils(unittest.TestCase):
         # Create test indexed_function
         mock_indexed_functions = MockFunction(bindings=[mock_blob, mock_http])
 
-        dict_repr = utils.get_raw_bindings(mock_indexed_functions, mock_input_types)
+        dict_repr, logs = utils.get_raw_bindings(
+            mock_indexed_functions, mock_input_types
+        )
         self.assertEqual(
             dict_repr,
-            ['{"direction": "IN", "dataType": null, "type": "blob", '
-             '"properties": {"SupportsDeferredBinding": false}}',
-             '{"direction": "OUT", "dataType": null, "type": "httpResponse", '
-             '"properties": {"SupportsDeferredBinding": false}}'],
+            [
+                '{"direction": "IN", "dataType": null, "type": "blob", '
+                '"properties": {"SupportsDeferredBinding": false}}',
+                '{"direction": "OUT", "dataType": null, "type": "httpResponse", '
+                '"properties": {"SupportsDeferredBinding": false}}',
+            ],
         )
+        self.assertEqual(logs, {"$return": (None, "False"), "blob": (bytes, "False")})
 
     def test_get_dict_repr_init_params(self):
         # Create mock blob
@@ -158,7 +169,9 @@ class TestUtils(unittest.TestCase):
         # Create test indexed_function
         mock_indexed_functions = MockFunction(bindings=[mock_blob])
 
-        dict_repr = utils.get_raw_bindings(mock_indexed_functions, mock_input_types)
+        dict_repr, logs = utils.get_raw_bindings(
+            mock_indexed_functions, mock_input_types
+        )
         self.assertEqual(
             dict_repr,
             [
@@ -167,6 +180,8 @@ class TestUtils(unittest.TestCase):
                 '{"SupportsDeferredBinding": true}}'
             ],
         )
+
+        self.assertEqual(logs, {"client": (sdkType.SdkType, "True")})
 
     def test_binding_data_type(self):
         mock_blob = utils.Binding(


### PR DESCRIPTION
This PR changes `get_dict_repr` to return the raw bindings of a function plus a dictionary containing the binding name (unique key), its pytype, and whether or not deferred bindings is enabled for this binding.

This additional dictionary will be returned and used in the worker for logging purposes. 

Currently, the worker logs the function name and bindings for each function in a function app in this format: 
**Function Name: blobTrigger, Function Binding: (blobTrigger, client)**

With this change, the worker log would look like: 
For a function using deferred bindings (library is imported & at least one sdk type defined):
**Function Name: blobTrigger, Function Binding: (blobTrigger, client, {BlobClient: True}), (httpRequest, $req, {http: False})**

For a function not using deferred bindings (library may or may not be imported, no sdk type defined):
**Function Name: blobTrigger, Function Binding: (blobTrigger, file,)**

This would allow us to query and measure usage of this feature as well as the most popular SDK types being used.

NOTE: this is a not a breaking change for the blob extension but will require updating the blob extension tests
