### PR TITLE
fix: tests python 3.8 for base and fastapi

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -36,6 +36,8 @@ extends:
          compiled:
            enabled: true # still only runs for default branch
          runSourceLanguagesInSourceAnalysis: true
+    settings:
+      skipBuildTagsForGitHubPullRequests: $(System.PullRequest.IsFork)
 
     stages:
       - stage: Build

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -34,7 +34,7 @@ extends:
     sdl:
       codeql:
          compiled:
-           enabled: true # only runs for default branch
+           enabled: true # only runs for dev branch
          runSourceLanguagesInSourceAnalysis: true
     settings:
       skipBuildTagsForGitHubPullRequests: $(System.PullRequest.IsFork)

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -34,7 +34,7 @@ extends:
     sdl:
       codeql:
          compiled:
-           enabled: true # still only runs for default branch
+           enabled: true # only runs for default branch
          runSourceLanguagesInSourceAnalysis: true
     settings:
       skipBuildTagsForGitHubPullRequests: $(System.PullRequest.IsFork)

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -34,7 +34,7 @@ extends:
     sdl:
       codeql:
          compiled:
-           enabled: true # only runs for dev branch
+           enabled: true # still only runs for default branch
          runSourceLanguagesInSourceAnalysis: true
     settings:
       skipBuildTagsForGitHubPullRequests: $(System.PullRequest.IsFork)

--- a/eng/templates/official/jobs/base-unit-tests.yml
+++ b/eng/templates/official/jobs/base-unit-tests.yml
@@ -4,6 +4,8 @@ jobs:
 
     strategy:
       matrix:
+        python38:
+            PYTHON_VERSION: '3.8'
         python39:
           PYTHON_VERSION: '3.9'
         python310:

--- a/eng/templates/official/jobs/base-unit-tests.yml
+++ b/eng/templates/official/jobs/base-unit-tests.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         python38:
-            PYTHON_VERSION: '3.8'
+          PYTHON_VERSION: '3.8'
         python39:
           PYTHON_VERSION: '3.9'
         python310:

--- a/eng/templates/official/jobs/fastapi-unit-tests.yml
+++ b/eng/templates/official/jobs/fastapi-unit-tests.yml
@@ -4,6 +4,8 @@ jobs:
 
     strategy:
       matrix:
+        python38:
+          PYTHON_VERSION: '3.8'
         python39:
           PYTHON_VERSION: '3.9'
         python310:


### PR DESCRIPTION
Missed running base and fastapi tests on Python 3.8.

Allows running public build on forks.