### PR TITLE
fix: clean nones in raw bindings

### DIFF
--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/utils.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/utils.py
@@ -250,6 +250,9 @@ def get_raw_bindings(indexed_function, input_types):
     bindings_logs = {}
     for b in indexed_function._bindings:
         dict_repr, logs = Binding.get_dict_repr(b, input_types)
-        binding_dict_repr.append(json.dumps(dict_repr, cls=StringifyEnumJsonEncoder))
+        clean_dict_repr = BuildDictMeta.clean_nones(dict_repr)
+        binding_dict_repr.append(
+            json.dumps(clean_dict_repr, cls=StringifyEnumJsonEncoder)
+        )
         bindings_logs.update(logs)
     return binding_dict_repr, bindings_logs

--- a/azurefunctions-extensions-base/tests/test_utils.py
+++ b/azurefunctions-extensions-base/tests/test_utils.py
@@ -63,7 +63,7 @@ class TestUtils(unittest.TestCase):
             dict_repr,
             [
                 '{"direction": "IN", '
-                '"dataType": null, "type": "blob", '
+                '"type": "blob", '
                 '"properties": '
                 '{"SupportsDeferredBinding": true}}'
             ],
@@ -98,7 +98,7 @@ class TestUtils(unittest.TestCase):
             dict_repr,
             [
                 '{"direction": "IN", '
-                '"dataType": null, "type": "blob", '
+                '"type": "blob", '
                 '"properties": '
                 '{"SupportsDeferredBinding": false}}'
             ],
@@ -138,9 +138,9 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(
             dict_repr,
             [
-                '{"direction": "IN", "dataType": null, "type": "blob", '
+                '{"direction": "IN", "type": "blob", '
                 '"properties": {"SupportsDeferredBinding": false}}',
-                '{"direction": "OUT", "dataType": null, "type": "httpResponse", '
+                '{"direction": "OUT", "type": "httpResponse", '
                 '"properties": {"SupportsDeferredBinding": false}}',
             ],
         )
@@ -175,8 +175,46 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(
             dict_repr,
             [
-                '{"direction": "IN", "dataType": null, '
-                '"type": "blob", "test": null, "properties": '
+                '{"direction": "IN", '
+                '"type": "blob", "properties": '
+                '{"SupportsDeferredBinding": true}}'
+            ],
+        )
+
+        self.assertEqual(logs, {"client": {sdkType.SdkType: "True"}})
+
+    def test_get_dict_repr_clean_nones(self):
+        # Create mock blob
+        meta._ConverterMeta._bindings = {"blob"}
+
+        # Create test binding
+        mock_blob = MockInitParams(
+            name="client",
+            direction=utils.BindingDirection.IN,
+            data_type=None,
+            type="blob",
+            path=None,
+            init_params=["test", "type", "direction", "path"],
+        )
+
+        # Create test input_types dict
+        mock_input_types = {
+            "client": MockParamTypeInfo(
+                binding_name="blobTrigger", pytype=sdkType.SdkType
+            )
+        }
+
+        # Create test indexed_function
+        mock_indexed_functions = MockFunction(bindings=[mock_blob])
+
+        dict_repr, logs = utils.get_raw_bindings(
+            mock_indexed_functions, mock_input_types
+        )
+        self.assertEqual(
+            dict_repr,
+            [
+                '{"direction": "IN", '
+                '"type": "blob", "properties": '
                 '{"SupportsDeferredBinding": true}}'
             ],
         )


### PR DESCRIPTION
Previously, if a binding parameter was not defined, the corresponding raw binding would look like `"param_name": null`
This causes an issue where the host sees that the param has been defined, tries to parse it, and finds that the value is unexpectedly null.

The fix is to clean out any values that are set to None in the raw bindings. If a parameter is not set, it will not be added and sent back to the worker.

Fixes: https://github.com/Azure/azure-functions-python-worker/issues/1529