### PR TITLE
fix: add default credential for MI

### DIFF
--- a/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/blobClient.py
+++ b/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/blobClient.py
@@ -45,8 +45,9 @@ class BlobClient(SdkType):
         """
         if self._data:
             blob_service_client = (
-                BlobServiceClient(account_url=self._connection,
-                                  credential=DefaultAzureCredential())
+                BlobServiceClient(
+                    account_url=self._connection, credential=DefaultAzureCredential()
+                )
                 if self._using_managed_identity
                 else BlobServiceClient.from_connection_string(self._connection)
             )

--- a/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/blobClient.py
+++ b/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/blobClient.py
@@ -45,7 +45,8 @@ class BlobClient(SdkType):
         """
         if self._data:
             blob_service_client = (
-                BlobServiceClient(account_url=self._connection, credential=DefaultAzureCredential())
+                BlobServiceClient(account_url=self._connection,
+                                  credential=DefaultAzureCredential())
                 if self._using_managed_identity
                 else BlobServiceClient.from_connection_string(self._connection)
             )

--- a/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/blobClient.py
+++ b/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/blobClient.py
@@ -4,6 +4,7 @@
 import json
 from typing import Union
 
+from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient
 from azurefunctions.extensions.base import Datum, SdkType
 from .utils import get_connection_string, using_managed_identity
@@ -44,7 +45,7 @@ class BlobClient(SdkType):
         """
         if self._data:
             blob_service_client = (
-                BlobServiceClient(account_url=self._connection)
+                BlobServiceClient(account_url=self._connection, credential=DefaultAzureCredential())
                 if self._using_managed_identity
                 else BlobServiceClient.from_connection_string(self._connection)
             )

--- a/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/containerClient.py
+++ b/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/containerClient.py
@@ -37,8 +37,9 @@ class ContainerClient(SdkType):
     def get_sdk_type(self):
         if self._data:
             blob_service_client = (
-                BlobServiceClient(account_url=self._connection,
-                                  credential=DefaultAzureCredential())
+                BlobServiceClient(
+                    account_url=self._connection, credential=DefaultAzureCredential()
+                )
                 if self._using_managed_identity
                 else BlobServiceClient.from_connection_string(self._connection)
             )

--- a/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/containerClient.py
+++ b/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/containerClient.py
@@ -4,6 +4,7 @@
 import json
 from typing import Union
 
+from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient
 from azurefunctions.extensions.base import Datum, SdkType
 from .utils import get_connection_string, using_managed_identity
@@ -36,7 +37,7 @@ class ContainerClient(SdkType):
     def get_sdk_type(self):
         if self._data:
             blob_service_client = (
-                BlobServiceClient(account_url=self._connection)
+                BlobServiceClient(account_url=self._connection, credential=DefaultAzureCredential())
                 if self._using_managed_identity
                 else BlobServiceClient.from_connection_string(self._connection)
             )

--- a/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/containerClient.py
+++ b/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/containerClient.py
@@ -37,7 +37,8 @@ class ContainerClient(SdkType):
     def get_sdk_type(self):
         if self._data:
             blob_service_client = (
-                BlobServiceClient(account_url=self._connection, credential=DefaultAzureCredential())
+                BlobServiceClient(account_url=self._connection,
+                                  credential=DefaultAzureCredential())
                 if self._using_managed_identity
                 else BlobServiceClient.from_connection_string(self._connection)
             )

--- a/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/storageStreamDownloader.py
+++ b/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/storageStreamDownloader.py
@@ -37,8 +37,9 @@ class StorageStreamDownloader(SdkType):
     def get_sdk_type(self):
         if self._data:
             blob_service_client = (
-                BlobServiceClient(account_url=self._connection,
-                                  credential=DefaultAzureCredential())
+                BlobServiceClient(
+                    account_url=self._connection, credential=DefaultAzureCredential()
+                )
                 if self._using_managed_identity
                 else BlobServiceClient.from_connection_string(self._connection)
             )

--- a/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/storageStreamDownloader.py
+++ b/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/storageStreamDownloader.py
@@ -37,7 +37,8 @@ class StorageStreamDownloader(SdkType):
     def get_sdk_type(self):
         if self._data:
             blob_service_client = (
-                BlobServiceClient(account_url=self._connection, credential=DefaultAzureCredential())
+                BlobServiceClient(account_url=self._connection,
+                                  credential=DefaultAzureCredential())
                 if self._using_managed_identity
                 else BlobServiceClient.from_connection_string(self._connection)
             )

--- a/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/storageStreamDownloader.py
+++ b/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/storageStreamDownloader.py
@@ -4,6 +4,7 @@
 import json
 from typing import Union
 
+from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient
 from azurefunctions.extensions.base import Datum, SdkType
 from .utils import get_connection_string, using_managed_identity
@@ -36,7 +37,7 @@ class StorageStreamDownloader(SdkType):
     def get_sdk_type(self):
         if self._data:
             blob_service_client = (
-                BlobServiceClient(account_url=self._connection)
+                BlobServiceClient(account_url=self._connection, credential=DefaultAzureCredential())
                 if self._using_managed_identity
                 else BlobServiceClient.from_connection_string(self._connection)
             )

--- a/azurefunctions-extensions-bindings-blob/pyproject.toml
+++ b/azurefunctions-extensions-bindings-blob/pyproject.toml
@@ -25,8 +25,8 @@ classifiers= [
     ]
 dependencies = [
     'azurefunctions-extensions-base',
-    'azure-storage-blob==12.24.0',
-    'azure-identity==1.19.0'
+    'azure-storage-blob~=12.24.0',
+    'azure-identity~=1.19.0'
     ]
 
 [project.optional-dependencies]

--- a/azurefunctions-extensions-bindings-blob/pyproject.toml
+++ b/azurefunctions-extensions-bindings-blob/pyproject.toml
@@ -25,7 +25,8 @@ classifiers= [
     ]
 dependencies = [
     'azurefunctions-extensions-base',
-    'azure-storage-blob==12.23.1'
+    'azure-storage-blob==12.23.1',
+    'azure-identity==1.19.0'
     ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
If Managed Identity is used, a credential is required to authenticate the request. This change adds a DefaultAzureCredential to authenticate creation of the BlobServiceClient. There is no change if Managed Identity is not used.

Fixes: https://github.com/Azure/azure-functions-python-worker/issues/1603