### PR TITLE
build: install compatible deps for fastapi

### DIFF
--- a/azurefunctions-extensions-http-fastapi/pyproject.toml
+++ b/azurefunctions-extensions-http-fastapi/pyproject.toml
@@ -26,9 +26,9 @@ classifiers= [
     ]
 dependencies = [
         'azurefunctions-extensions-base',
-        'fastapi==0.115.2',
-        'uvicorn==0.32.0',
-        'pydantic==2.10.1',
+        'fastapi~=0.115.0',
+        'uvicorn~=0.32.0',
+        'pydantic~=2.10.0',
     ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Updates pyproject.toml to install compatible versions of dependencies, not specific versions.

Updates pydantic version to ~=2.10.0