### PR TITLE
build: update eventhub to 1.0.0b1

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,4 +9,4 @@
 # AZURE FUNCTIONS TEAM
 # For all file changes, github would automatically
 # include the following people in the PRs.
-* @vrdmr @gavin-aguiar @hallvictoria
+* @vrdmr @gavin-aguiar @hallvictoria @EvanR-Dev

--- a/azurefunctions-extensions-bindings-eventhub/samples/README.md
+++ b/azurefunctions-extensions-bindings-eventhub/samples/README.md
@@ -15,7 +15,7 @@ urlFragment: extension-eventhub-samples
 These are code samples that show common scenario operations with the Azure Functions Extension EventHub library.
 
 These samples relate to the Azure EventHub library being used as part of a Python Function App. For
-examples on how to use the Azure EventHub library, please see [Azure EventHub samples](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/eventhub/azure-eventhub/samples)
+examples on how to use the Azure EventHub library, please see [Azure EventHub samples](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/eventhub/azure-eventhub/samples).
 
 * [eventhub_samples_eventdata](https://github.com/Azure/azure-functions-python-extensions/tree/dev/azurefunctions-extensions-bindings-eventhub/samples/eventhub_samples_eventdata)  - Examples for using the EventData type:
     * From EventHubTrigger


### PR DESCRIPTION
This PR is a no-op -- the version is already set to 1.0.0b1 in dev. To help maintain consistency, this PR will mark what changes are included in the `azurefunctions-extensions-bindings-eventhub==1.0.0b1` release.