### PR TITLE
build: bump fastapi deps within major version

### DIFF
--- a/azurefunctions-extensions-http-fastapi/pyproject.toml
+++ b/azurefunctions-extensions-http-fastapi/pyproject.toml
@@ -26,9 +26,9 @@ classifiers= [
     ]
 dependencies = [
         'azurefunctions-extensions-base',
-        'fastapi~=0.115.0',
-        'uvicorn~=0.32.0',
-        'pydantic~=2.10.0',
+        'fastapi>=0.115.0,<1.0',
+        'uvicorn>=0.32.0,<1.0',
+        'pydantic>=2.10.0,<3.0',
     ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Bumping FastApi deps within major version.

Latest dependency versions:
`fastapi`: 0.116.1
`uvicorn`: 0.35.0
`pydantic`: 2.11.7

When a new major version is released for these, we will not automatically allow it to be installed -- instead, limiting the versions within the same major version allows us to check for any potential breaking changes and then update.