### PR TITLE
build: fix release pipeline

### DIFF
--- a/azurefunctions-extensions-bindings-cosmosdb/samples/cosmosdb_samples_containerproxy/function_app.py
+++ b/azurefunctions-extensions-bindings-cosmosdb/samples/cosmosdb_samples_containerproxy/function_app.py
@@ -14,14 +14,15 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
 """
 FOLDER: cosmosdb_samples_containerproxy
 DESCRIPTION:
-    These samples demonstrate how to obtain a ContainerProxy from a Cosmos DB Input function app binding.
+    These samples demonstrate how to obtain a ContainerProxy from a Cosmos DB Input
+    function app binding.
 USAGE:
     Set the environment variables with your own values before running the
     sample:
     1) CosmosDBConnection - the connection string to your Cosmos DB instance
 
-    Set database_name and container_name to the database name the and container name you want to use
-    as inputs to the function (required).
+    Set database_name and container_name to the database name the and container name you want
+    to use as inputs to the function (required).
 """
 
 
@@ -31,7 +32,8 @@ USAGE:
                      database_name="db_name",
                      container_name="container_name")
 def get_docs(req: func.HttpRequest, container: cosmos.ContainerProxy):
-    docs = container.query_items(query="SELECT * FROM c", enable_cross_partition_query=True)
+    docs = container.query_items(query="SELECT * FROM c",
+                                 enable_cross_partition_query=True)
     for d in docs:
         logging.info(f"Found document: {d}")
 

--- a/azurefunctions-extensions-bindings-cosmosdb/samples/cosmosdb_samples_cosmosclient/function_app.py
+++ b/azurefunctions-extensions-bindings-cosmosdb/samples/cosmosdb_samples_cosmosclient/function_app.py
@@ -9,7 +9,8 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
 """
 FOLDER: cosmosdb_samples_cosmosclient
 DESCRIPTION:
-    These samples demonstrate how to obtain a CosmosClient from a Cosmos DB Input function app binding.
+    These samples demonstrate how to obtain a CosmosClient from a Cosmos DB Input
+    function app binding.
 USAGE:
     Set the environment variables with your own values before running the
     sample:

--- a/azurefunctions-extensions-bindings-cosmosdb/samples/cosmosdb_samples_databaseproxy/function_app.py
+++ b/azurefunctions-extensions-bindings-cosmosdb/samples/cosmosdb_samples_databaseproxy/function_app.py
@@ -9,13 +9,15 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
 """
 FOLDER: cosmosdb_samples_databaseproxy
 DESCRIPTION:
-    These samples demonstrate how to obtain a DatabaseProxy from a Cosmos DB Input function app binding.
+    These samples demonstrate how to obtain a DatabaseProxy from a Cosmos DB Input
+    function app binding.
 USAGE:
     Set the environment variables with your own values before running the
     sample:
     1) CosmosDBConnection - the connection string to your Cosmos DB instance
 
-    Set database_name to the database you want to use as an input to the function (required).
+    Set database_name to the database you want to use as an input to
+    the function (required).
 """
 
 

--- a/eng/ci/extension-release.yml
+++ b/eng/ci/extension-release.yml
@@ -22,10 +22,6 @@ extends:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
-    sdl:
-      codeSignValidation:
-        enabled: true
-        break: true
 
     stages:
       - stage: Release

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -47,3 +47,5 @@ extends:
         dependsOn: Build
         jobs:
           - template: /eng/templates/official/jobs/unit-tests.yml@self
+            parameters:
+              PoolName: 1es-pool-azfunc

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -47,3 +47,5 @@ extends:
         dependsOn: Build
         jobs:
           - template: /eng/templates/official/jobs/unit-tests.yml@self
+            parameters:
+              PoolName: 1es-pool-azfunc-public

--- a/eng/templates/official/jobs/publish-release.yml
+++ b/eng/templates/official/jobs/publish-release.yml
@@ -39,12 +39,12 @@ jobs:
 
           # Create PR
           Write-Host "Creating PR draft in GitHub"
-          $body = (@{head="$newBranch";base="dev";body="Python Extension [$extensionName] Version [$newLibraryVersion](https://github.com/Azure/azure-functions-python-extensions/releases/tag/$extensionName/$newLibraryVersion)";draft=$true;maintainer_can_modify=$true;title="build: update $extensionName version to $newLibraryVersion"} | ConvertTo-Json -Compress)
-          $response = Invoke-WebRequest -Headers @{"Cache-Control"="no-cache";"Content-Type"="application/json";"Authorization"="Basic $credential";"Accept"="application/vnd.github.v3+json"} -Method Post -Body "$body" -Uri "https://api.github.com/repos/Azure/azure-functions-python-worker/pulls"
+          $body = (@{head="$newBranch";base="dev";body="Python Extension [$extensionName] Version [$newLibraryVersion]";draft=$true;maintainer_can_modify=$true;title="build: update $extensionName version to $newLibraryVersion"} | ConvertTo-Json -Compress)
+          $response = Invoke-WebRequest -Headers @{"Cache-Control"="no-cache";"Content-Type"="application/json";"Authorization"="Basic $credential";"Accept"="application/vnd.github.v3+json"} -Method Post -Body "$body" -Uri "https://api.github.com/repos/Azure/azure-functions-python-extensions/pulls"
       
           # Return Value
           if ($response.StatusCode -ne 201) {
-              Write-Host "Failed to create PR in Azure Functions Python Worker"
+              Write-Host "Failed to create PR in Azure Functions Python Extensions"
               exit -1
           }
       

--- a/eng/templates/official/jobs/publish-release.yml
+++ b/eng/templates/official/jobs/publish-release.yml
@@ -8,6 +8,8 @@ jobs:
     os: linux
   steps:
   - powershell: |
+      $githubUser = "$(GithubUser)"
+      $githubToken = "$(GithubPat)"
       $githubToken = "$(GithubPat)"
       $newLibraryVersion = "$(NewLibraryVersion)"
       $extensionName= "$(ExtensionName)"
@@ -17,6 +19,9 @@ jobs:
           # Create GitHub credential
           git config --global user.name "AzureFunctionsPython"
           git config --global user.email "azfunc@microsoft.com"
+      
+          # Create GitHub credential
+          $credential = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("${githubUser}:${githubToken}"))
       
           # Heading to Artifact Repository
           Write-Host "Operating based on $stagingDirectory/azure-functions-python-extensions"
@@ -31,6 +36,21 @@ jobs:
           # Create release branch release/X.Y.Z
           Write-Host "Creating release branch release/$newLibraryVersion"
           git push --repo="https://$githubToken@github.com/Azure/azure-functions-python-extensions.git"
+
+          # Create PR
+          Write-Host "Creating PR draft in GitHub"
+          $body = (@{head="$newBranch";base="dev";body="Python Extension [$extensionName] Version [$newLibraryVersion](https://github.com/Azure/azure-functions-python-extensions/releases/tag/$extensionName/$newLibraryVersion)";draft=$true;maintainer_can_modify=$true;title="build: update $extensionName version to $newLibraryVersion"} | ConvertTo-Json -Compress)
+          $response = Invoke-WebRequest -Headers @{"Cache-Control"="no-cache";"Content-Type"="application/json";"Authorization"="Basic $credential";"Accept"="application/vnd.github.v3+json"} -Method Post -Body "$body" -Uri "https://api.github.com/repos/Azure/azure-functions-python-worker/pulls"
+      
+          # Return Value
+          if ($response.StatusCode -ne 201) {
+              Write-Host "Failed to create PR in Azure Functions Python Worker"
+              exit -1
+          }
+      
+          $draftUrl = $response | ConvertFrom-Json | Select -expand url
+          Write-Host "PR draft created in $draftUrl"
+          
       } else {
           Write-Host "NewLibraryVersion $newLibraryVersion is malformed (example: 1.5.0)"
           exit -1
@@ -79,6 +99,7 @@ jobs:
       
           # Push tag to remote
           git push origin $extensionName/$newLibraryVersion
+
       } else {
           Write-Host "NewLibraryVersion $newLibraryVersion is malformed (example: 1.5.0)"
           exit -1
@@ -153,17 +174,17 @@ jobs:
       
           # Modify Extension $extensionName Version in pyproject.toml
           Write-Host "Replacing Extension $extensionName version in worker's pyproject.toml"
-          ((Get-Content pyproject.toml) -replace '"$(ExtensionName)==(\d)+.(\d)+.*"','"$(ExtensionName)==$(NewLibraryVersion)"' -join "`n") + "`n" | Set-Content -NoNewline pyproject.toml
-      
+          ((Get-Content workers/pyproject.toml) -replace '"$(ExtensionName)==(\d)+.(\d)+.*"','"$(ExtensionName)==$(NewLibraryVersion)"' -join "`n") + "`n" | Set-Content -NoNewline workers/pyproject.toml
+
           # Commit Python Version
           Write-Host "Pushing $newBranch to azure-functions-python-worker repo"
-          git add pyproject.toml
+          git add workers/pyproject.toml
           git commit -m "build: update $extensionName version to $newLibraryVersion"
           git push origin $newBranch
       
           # Create PR
           Write-Host "Creating PR draft in GitHub"
-          $body = (@{head="$newBranch";base="dev";body="Python Extension [$extensionName] Version [$newLibraryVersion](https://github.com/Azure/azure-functions-python-extensions/releases/tag/$extensionName/$newLibraryVersion)";draft=$true;maintainer_can_modify=$true;title="buikld: update $extensionName version to $newLibraryVersion"} | ConvertTo-Json -Compress)
+          $body = (@{head="$newBranch";base="dev";body="Python Extension [$extensionName] Version [$newLibraryVersion](https://github.com/Azure/azure-functions-python-extensions/releases/tag/$extensionName/$newLibraryVersion)";draft=$true;maintainer_can_modify=$true;title="build: update $extensionName version to $newLibraryVersion"} | ConvertTo-Json -Compress)
           $response = Invoke-WebRequest -Headers @{"Cache-Control"="no-cache";"Content-Type"="application/json";"Authorization"="Basic $credential";"Accept"="application/vnd.github.v3+json"} -Method Post -Body "$body" -Uri "https://api.github.com/repos/Azure/azure-functions-python-worker/pulls"
       
           # Return Value
@@ -238,34 +259,3 @@ jobs:
           exit -1
       }
     displayName: 'Publish package to pypi.org'
-
-- job: "MergeBack"
-  dependsOn: ['PyPIPackage']
-  displayName: 'Merge Back'
-  steps:
-  - powershell: |
-      $githubToken = "$(GithubPat)"
-      $newLibraryVersion = "$(newLibraryVersion)"
-      $extensionName= "$(ExtensionName)"
-      $extensionDirectory = "$(ExtensionDirectory)"
-      
-      if($newLibraryVersion -match '(\d)+.(\d)+.(\d)+') {
-          # Create GitHub credential
-          git config --global user.name "AzureFunctionsPython"
-          git config --global user.email "azfunc@microsoft.com"
-      
-          # Clone Repository
-          git clone https://$githubToken@github.com/Azure/azure-functions-python-extensions
-          Write-Host "Cloned azure-functions-python-extensions into local"
-          Set-Location "azure-functions-python-extensions"
-      
-          # Merge back to dev
-          Write-Host "Merging $extensionName/release/$newLibraryVersion back to dev"
-          git checkout dev
-          git merge "origin/$extensionName/release/$newLibraryVersion"
-          git push origin dev
-      } else {
-          Write-Host "newLibraryVersion $newLibraryVersion is malformed (example: 1.1.8)"
-          exit -1
-      }
-    displayName: 'Merge release/x.y.z back to dev'

--- a/eng/templates/official/jobs/unit-tests.yml
+++ b/eng/templates/official/jobs/unit-tests.yml
@@ -14,6 +14,11 @@ parameters:
       python313:
         PYTHON_VERSION: '3.13'
 
+pool:
+      name: ${{ parameters.PoolName }}
+      image: 1es-ubuntu-22.04
+      os: linux
+
 jobs:
   - job: "BaseTests"
     displayName: "Base Extension Tests"
@@ -72,6 +77,11 @@ jobs:
           cd azurefunctions-extensions-bindings-cosmosdb
           python -m pip install -U -e .[dev]
         displayName: 'Install CosmosDB Dependencies'
+      - bash: |
+          docker pull mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
+          docker run --detach --publish 8081:8081 --publish 1234:1234 mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
+          docker ps
+        displayName: "Start CosmosDB Emulator"
       - bash: |
           python -m pytest -q --instafail azurefunctions-extensions-bindings-cosmosdb/tests/
         env:

--- a/eng/templates/official/jobs/unit-tests.yml
+++ b/eng/templates/official/jobs/unit-tests.yml
@@ -14,11 +14,6 @@ parameters:
       python313:
         PYTHON_VERSION: '3.13'
 
-pool:
-  name: ${{ parameters.PoolName }}
-  image: 1es-ubuntu-22.04
-  os: linux
-
 jobs:
   - job: "BaseTests"
     displayName: "Base Extension Tests"
@@ -65,6 +60,10 @@ jobs:
   - job: "CosmosDBTests"
     displayName: "CosmosDB Extension Tests"
     dependsOn: []
+    pool:
+      name: ${{ parameters.PoolName }}
+      image: 1es-ubuntu-22.04
+      os: linux
     strategy:
       matrix: ${{ parameters.python_versions }}
     condition: always()

--- a/eng/templates/official/jobs/unit-tests.yml
+++ b/eng/templates/official/jobs/unit-tests.yml
@@ -1,4 +1,7 @@
 parameters:
+  - name: PoolName
+    type: string
+    default: ''
   - name: python_versions
     type: object
     default:

--- a/eng/templates/official/jobs/unit-tests.yml
+++ b/eng/templates/official/jobs/unit-tests.yml
@@ -14,10 +14,10 @@ parameters:
       python313:
         PYTHON_VERSION: '3.13'
 
-    pool:
-      name: ${{ parameters.PoolName }}
-      image: 1es-ubuntu-22.04
-      os: linux
+pool:
+  name: ${{ parameters.PoolName }}
+  image: 1es-ubuntu-22.04
+  os: linux
 
 jobs:
   - job: "BaseTests"

--- a/eng/templates/official/jobs/unit-tests.yml
+++ b/eng/templates/official/jobs/unit-tests.yml
@@ -14,7 +14,7 @@ parameters:
       python313:
         PYTHON_VERSION: '3.13'
 
-pool:
+    pool:
       name: ${{ parameters.PoolName }}
       image: 1es-ubuntu-22.04
       os: linux


### PR DESCRIPTION
- Removes CodeQL from release pipeline (not needed, as we are not doing any builds)
- Creates PR in extensions repo by default
- Fixes worker PR title (buikld -> build)
- Refactors worker PR step to edit `pyproject` inside `workers/` directory
- Fixes CosmosDB tests -- these tests require a connection string to work. Since production resources now prevent local authentication, we use the emulator connection string