### PR TITLE
Add facility for AzureWebJobStorage

### DIFF
--- a/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/utils.py
+++ b/azurefunctions-extensions-bindings-blob/azurefunctions/extensions/bindings/blob/utils.py
@@ -43,6 +43,8 @@ def get_connection_string(connection_name: str) -> str:
         return os.getenv(connection_name + "__serviceUri")
     elif connection_name + "__blobServiceUri" in os.environ:
         return os.getenv(connection_name + "__blobServiceUri")
+    elif connection_name == "AzureWebJobsStorage" and connection_name + "__accountName" in os.environ:
+        return f"https://{os.getenv(connection_name + "__accountName")}.blob.core.windows.net"
     else:
         raise ValueError(
             f"Storage account connection name {connection_name} does not exist. "
@@ -56,9 +58,11 @@ def using_system_managed_identity(connection_name: str) -> bool:
     the provided connection string has either of the two suffixes:
     __serviceUri or __blobServiceUri.
     """
-    return (os.getenv(connection_name + "__serviceUri") is not None) or (
-        os.getenv(connection_name + "__blobServiceUri") is not None
-    )
+    return (os.getenv(connection_name + "__serviceUri") is not None) or 
+        (os.getenv(connection_name + "__blobServiceUri") is not None) or (
+            connection_name == "AzureWebJobsStorage" and 
+            os.getenv(connection_name + "__accountName") is not None
+        )
 
 
 def using_user_managed_identity(connection_name: str) -> bool:


### PR DESCRIPTION
# Issue
As per the [documentation](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob&pivots=programming-language-python#connecting-to-host-storage-with-an-identity), if we are using `AzureWebJobsStorage` environment setting, we can specify `AzureWebJobsStorage__accountName` instead of `__blobServiceUri` or `__serviceUri`. 


The existing implementation doesn't have this facility and incorrectly throws an error incorrectly not recognizing the environment setting

# Fix
Add the code to allow `__accountName` if the `AzureWebJobsStorage` environment setting is used.