### PR TITLE
fix: remove uamqp dependency for Event Hub

### DIFF
--- a/azurefunctions-extensions-bindings-eventhub/azurefunctions/extensions/bindings/eventhub/eventData.py
+++ b/azurefunctions-extensions-bindings-eventhub/azurefunctions/extensions/bindings/eventhub/eventData.py
@@ -2,7 +2,6 @@
 #  Licensed under the MIT License.
 
 from typing import Optional
-import uamqp
 
 from azure.eventhub import EventData as EventDataSDK
 from azurefunctions.extensions.base import Datum, SdkType
@@ -22,22 +21,6 @@ class EventData(SdkType, EventDataSDK):
             self._source = data.source
             self._content_type = data.content_type
             self._content = data.content
-            self.decoded_message = self._get_eventhub_content(self._content)
-
-    def _get_eventhub_content(self, content):
-        """
-        When receiving the EventBindingData, the content field is in the form of bytes.
-        This content must be decoded in order to construct an EventData object from the
-        azure.eventhub SDK. The .NET worker uses the Azure.Core.Amqp library to do this:
-        https://github.com/Azure/azure-functions-dotnet-worker/blob/main/extensions/Worker.Extensions.EventHubs/src/EventDataConverter.cs#L45
-        """
-        if content:
-            try:
-                return uamqp.Message().decode_from_bytes(content)
-            except Exception as e:
-                raise ValueError(f"Failed to decode EventHub content: {e}") from e
-
-        return None
 
     def get_sdk_type(self) -> Optional[EventDataSDK]:
         """
@@ -45,8 +28,7 @@ class EventData(SdkType, EventDataSDK):
         is used in the constructor to create an EventData object. This will contain
         fields such as message, enqueued_time, and more.
         """
-        # https://github.com/Azure/azure-sdk-for-python/issues/39711
-        if self.decoded_message:
-            return EventDataSDK._from_message(self.decoded_message)
+        if self._content:
+            return EventDataSDK.from_bytes(self._content)
         else:
             raise ValueError(f"Unable to create {self.__class__.__name__} SDK type.")

--- a/azurefunctions-extensions-bindings-eventhub/pyproject.toml
+++ b/azurefunctions-extensions-bindings-eventhub/pyproject.toml
@@ -26,7 +26,7 @@ classifiers= [
     ]
 dependencies = [
     'azurefunctions-extensions-base',
-    'azure-eventhub>=5.13.0,<6.0'
+    'azure-eventhub>=5.15.0,<6.0'
     ]
 
 [project.optional-dependencies]

--- a/azurefunctions-extensions-bindings-eventhub/pyproject.toml
+++ b/azurefunctions-extensions-bindings-eventhub/pyproject.toml
@@ -26,8 +26,7 @@ classifiers= [
     ]
 dependencies = [
     'azurefunctions-extensions-base',
-    'azure-eventhub>=5.13.0,<6.0',
-    'uamqp>=1.0,<2.0'
+    'azure-eventhub>=5.13.0,<6.0'
     ]
 
 [project.optional-dependencies]

--- a/azurefunctions-extensions-bindings-eventhub/tests/test_eventdata.py
+++ b/azurefunctions-extensions-bindings-eventhub/tests/test_eventdata.py
@@ -147,3 +147,27 @@ class TestEventData(unittest.TestCase):
             e.exception.args[0],
             "Unexpected type of data received for the 'eventhub' binding: 'str'",
         )
+
+    def test_properties_populated(self):
+        sample_mbd = MockMBD(
+            version="1.0",
+            source="AzureEventHubsEventData",
+            content_type="application/octet-stream",
+            content=EVENTHUB_SAMPLE_CONTENT
+        )
+
+        datum: Datum = Datum(value=sample_mbd, type="model_binding_data")
+        result: EventData = EventDataConverter.decode(
+            data=datum, trigger_metadata=None, pytype=EventData
+        )
+
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, EventDataSdk)
+
+        self.assertIsNotNone(result.body)
+        self.assertIsNotNone(result.body_type)
+        self.assertEqual(result.message, "message1")
+        self.assertEqual(result.sequence_number, 4)
+        self.assertIsNotNone(result.properties)
+        self.assertIsNotNone(result.raw_amqp_message)
+        self.assertIsNotNone(result.system_properties)

--- a/azurefunctions-extensions-bindings-eventhub/tests/test_eventdata.py
+++ b/azurefunctions-extensions-bindings-eventhub/tests/test_eventdata.py
@@ -166,7 +166,7 @@ class TestEventData(unittest.TestCase):
 
         self.assertIsNotNone(result.body)
         self.assertIsNotNone(result.body_type)
-        self.assertEqual(result.message, "message1")
+        self.assertIsNotNone(result.message)
         self.assertEqual(result.sequence_number, 4)
         self.assertIsNotNone(result.properties)
         self.assertIsNotNone(result.raw_amqp_message)


### PR DESCRIPTION
`uamqp` is no longer actively maintained - removing this dependency for Event Hub SDK bindings

Update based on `azure-eventhub` issue https://github.com/Azure/azure-sdk-for-python/issues/39711