### PR TITLE
feat: add runtime base

### DIFF
--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/__init__.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/__init__.py
@@ -10,6 +10,11 @@ from .meta import (
     _ConverterMeta,
     get_binding_registry,
 )
+from .runtime import (
+    RuntimeTrackerMeta,
+    RuntimeBase,
+    RuntimeFeatureChecker,
+)
 from .sdkType import SdkType
 from .web import (
     HttpV2FeatureChecker,
@@ -39,6 +44,9 @@ __all__ = [
     "WebServer",
     "WebApp",
     "RequestSynchronizer",
+    "RuntimeTrackerMeta",
+    "RuntimeBase", 
+    "RuntimeFeatureChecker",
 ]
 
 __version__ = '1.1.0'

--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/__init__.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/__init__.py
@@ -45,7 +45,7 @@ __all__ = [
     "WebApp",
     "RequestSynchronizer",
     "RuntimeTrackerMeta",
-    "RuntimeBase", 
+    "RuntimeBase",
     "RuntimeFeatureChecker",
 ]
 

--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/runtime.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/runtime.py
@@ -71,7 +71,7 @@ class RuntimeBase(metaclass=RuntimeTrackerMeta):
     3. Implement all required event handler methods
 
     Example:
-        from runtimes.base import RuntimeBase
+        from azurefunctions.extensions.base import RuntimeBase
 
         class Runtime(RuntimeBase):
             runtime_name = "fastapi"

--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/runtime.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/runtime.py
@@ -1,0 +1,169 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""
+Runtime Base Classes and Metaclass Registration
+
+This module provides the core abstractions for runtime packages:
+- RuntimeTrackerMeta: Metaclass that auto-registers runtimes at import time
+- RuntimeBase: Abstract base class that all runtimes must extend
+- RuntimeFeatureChecker: Utility to check if a runtime is loaded
+"""
+
+import abc
+from abc import abstractmethod
+
+base_runtime_module = __name__
+
+
+class RuntimeTrackerMeta(type):
+    """
+    Metaclass that automatically registers runtime implementations.
+    
+    When a runtime class is defined with this metaclass, it automatically
+    registers its module name. This allows the proxy worker to discover
+    which runtime is loaded without explicit registration.
+    
+    Similar to ModuleTrackerMeta in azurefunctions.extensions.base
+    """
+    _module = None
+    _runtime_name = None
+    
+    def __new__(cls, name, bases, dct, **kwargs):
+        new_class = super().__new__(cls, name, bases, dct)
+        new_module = dct.get("__module__")
+        runtime_name = dct.get("runtime_name")
+        
+        # Only register if this is not the base module itself
+        if new_module != base_runtime_module:
+            if cls._module is None:
+                cls._module = new_module
+                cls._runtime_name = runtime_name
+            elif cls._module != new_module:
+                raise Exception(
+                    f"Only one runtime package shall be imported at a time. "
+                    f"{cls._module} and {new_module} are imported."
+                )
+        
+        return new_class
+    
+    @classmethod
+    def get_module(cls):
+        """Get the registered runtime module name"""
+        return cls._module
+    
+    @classmethod
+    def get_runtime_name(cls):
+        """Get the registered runtime name"""
+        return cls._runtime_name
+    
+    @classmethod
+    def module_imported(cls):
+        """Check if a runtime module has been imported"""
+        return cls._module is not None
+
+
+class RuntimeBase(metaclass=RuntimeTrackerMeta):
+    """
+    Abstract base class for all runtime implementations.
+    
+    Runtime packages (FastAPI, Flask, etc.) must:
+    1. Import this base class
+    2. Create a subclass with runtime_name defined
+    3. Implement all required event handler methods
+    
+    Example:
+        from runtimes.base import RuntimeBase
+        
+        class Runtime(RuntimeBase):
+            runtime_name = "fastapi"
+            
+            async def worker_init_request(self, request):
+                # Implementation
+                pass
+    """
+    
+    # Runtime identification (must be set by subclass)
+    runtime_name = None
+    
+    @abstractmethod
+    async def worker_init_request(self, request):
+        """
+        Handle WorkerInitRequest - Initialize the runtime
+        
+        Args:
+            request: WorkerInitRequest protobuf message
+            
+        Returns:
+            WorkerInitResponse protobuf message
+        """
+        raise NotImplementedError()
+    
+    @abstractmethod
+    async def functions_metadata_request(self, request):
+        """
+        Handle FunctionMetadataRequest - Return function metadata
+        
+        Args:
+            request: FunctionMetadataRequest protobuf message
+            
+        Returns:
+            FunctionMetadataResponse protobuf message
+        """
+        raise NotImplementedError()
+    
+    @abstractmethod
+    async def function_load_request(self, request):
+        """
+        Handle FunctionLoadRequest - Load a specific function
+        
+        Args:
+            request: FunctionLoadRequest protobuf message
+            
+        Returns:
+            FunctionLoadResponse protobuf message
+        """
+        raise NotImplementedError()
+    
+    @abstractmethod
+    async def invocation_request(self, request):
+        """
+        Handle InvocationRequest - Execute a function invocation
+        
+        Args:
+            request: InvocationRequest protobuf message
+            
+        Returns:
+            InvocationResponse protobuf message
+        """
+        raise NotImplementedError()
+    
+    @abstractmethod
+    async def function_environment_reload_request(self, request):
+        """
+        Handle FunctionEnvironmentReloadRequest - Reload the environment
+        
+        Args:
+            request: FunctionEnvironmentReloadRequest protobuf message
+            
+        Returns:
+            FunctionEnvironmentReloadResponse protobuf message
+        """
+        raise NotImplementedError()
+
+
+class RuntimeFeatureChecker:
+    """
+    Utility class to check if a runtime has been loaded.
+    
+    Similar to HttpV2FeatureChecker in azurefunctions.extensions.base
+    """
+    
+    @staticmethod
+    def runtime_loaded():
+        """Check if a runtime has been imported and registered"""
+        return RuntimeTrackerMeta.module_imported()
+    
+    @staticmethod
+    def get_runtime_name():
+        """Get the name of the loaded runtime"""
+        return RuntimeTrackerMeta.get_runtime_name()

--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/runtime.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/runtime.py
@@ -9,7 +9,6 @@ This module provides the core abstractions for runtime packages:
 - RuntimeFeatureChecker: Utility to check if a runtime is loaded
 """
 
-import abc
 from abc import abstractmethod
 
 base_runtime_module = __name__
@@ -18,21 +17,21 @@ base_runtime_module = __name__
 class RuntimeTrackerMeta(type):
     """
     Metaclass that automatically registers runtime implementations.
-    
+
     When a runtime class is defined with this metaclass, it automatically
     registers its module name. This allows the proxy worker to discover
     which runtime is loaded without explicit registration.
-    
+
     Similar to ModuleTrackerMeta in azurefunctions.extensions.base
     """
     _module = None
     _runtime_name = None
-    
+
     def __new__(cls, name, bases, dct, **kwargs):
         new_class = super().__new__(cls, name, bases, dct)
         new_module = dct.get("__module__")
         runtime_name = dct.get("runtime_name")
-        
+
         # Only register if this is not the base module itself
         if new_module != base_runtime_module:
             if cls._module is None:
@@ -43,19 +42,19 @@ class RuntimeTrackerMeta(type):
                     f"Only one runtime package shall be imported at a time. "
                     f"{cls._module} and {new_module} are imported."
                 )
-        
+
         return new_class
-    
+
     @classmethod
     def get_module(cls):
         """Get the registered runtime module name"""
         return cls._module
-    
+
     @classmethod
     def get_runtime_name(cls):
         """Get the registered runtime name"""
         return cls._runtime_name
-    
+
     @classmethod
     def module_imported(cls):
         """Check if a runtime module has been imported"""
@@ -65,86 +64,86 @@ class RuntimeTrackerMeta(type):
 class RuntimeBase(metaclass=RuntimeTrackerMeta):
     """
     Abstract base class for all runtime implementations.
-    
+
     Runtime packages (FastAPI, Flask, etc.) must:
     1. Import this base class
     2. Create a subclass with runtime_name defined
     3. Implement all required event handler methods
-    
+
     Example:
         from runtimes.base import RuntimeBase
-        
+
         class Runtime(RuntimeBase):
             runtime_name = "fastapi"
-            
+
             async def worker_init_request(self, request):
                 # Implementation
                 pass
     """
-    
+
     # Runtime identification (must be set by subclass)
     runtime_name = None
-    
+
     @abstractmethod
     async def worker_init_request(self, request):
         """
         Handle WorkerInitRequest - Initialize the runtime
-        
+
         Args:
             request: WorkerInitRequest protobuf message
-            
+
         Returns:
             WorkerInitResponse protobuf message
         """
         raise NotImplementedError()
-    
+
     @abstractmethod
     async def functions_metadata_request(self, request):
         """
         Handle FunctionMetadataRequest - Return function metadata
-        
+
         Args:
             request: FunctionMetadataRequest protobuf message
-            
+
         Returns:
             FunctionMetadataResponse protobuf message
         """
         raise NotImplementedError()
-    
+
     @abstractmethod
     async def function_load_request(self, request):
         """
         Handle FunctionLoadRequest - Load a specific function
-        
+
         Args:
             request: FunctionLoadRequest protobuf message
-            
+
         Returns:
             FunctionLoadResponse protobuf message
         """
         raise NotImplementedError()
-    
+
     @abstractmethod
     async def invocation_request(self, request):
         """
         Handle InvocationRequest - Execute a function invocation
-        
+
         Args:
             request: InvocationRequest protobuf message
-            
+
         Returns:
             InvocationResponse protobuf message
         """
         raise NotImplementedError()
-    
+
     @abstractmethod
     async def function_environment_reload_request(self, request):
         """
         Handle FunctionEnvironmentReloadRequest - Reload the environment
-        
+
         Args:
             request: FunctionEnvironmentReloadRequest protobuf message
-            
+
         Returns:
             FunctionEnvironmentReloadResponse protobuf message
         """
@@ -154,15 +153,15 @@ class RuntimeBase(metaclass=RuntimeTrackerMeta):
 class RuntimeFeatureChecker:
     """
     Utility class to check if a runtime has been loaded.
-    
+
     Similar to HttpV2FeatureChecker in azurefunctions.extensions.base
     """
-    
+
     @staticmethod
     def runtime_loaded():
         """Check if a runtime has been imported and registered"""
         return RuntimeTrackerMeta.module_imported()
-    
+
     @staticmethod
     def get_runtime_name():
         """Get the name of the loaded runtime"""

--- a/azurefunctions-extensions-base/tests/test_runtime.py
+++ b/azurefunctions-extensions-base/tests/test_runtime.py
@@ -1,0 +1,299 @@
+import unittest
+
+from azurefunctions.extensions.base.runtime import (
+    RuntimeBase,
+    RuntimeFeatureChecker,
+    RuntimeTrackerMeta,
+)
+
+
+class TestRuntimeTrackerMeta(unittest.TestCase):
+    def setUp(self):
+        # Reset the _module and _runtime_name attributes after each test
+        RuntimeTrackerMeta._module = None
+        RuntimeTrackerMeta._runtime_name = None
+        self.assertFalse(RuntimeFeatureChecker.runtime_loaded())
+
+    def test_classes_imported_from_same_module(self):
+        class TestRuntime1(metaclass=RuntimeTrackerMeta):
+            runtime_name = "test_runtime"
+
+        class TestRuntime2(metaclass=RuntimeTrackerMeta):
+            runtime_name = "test_runtime"
+
+        self.assertEqual(RuntimeTrackerMeta.get_module(), __name__)
+        self.assertEqual(RuntimeTrackerMeta.get_runtime_name(), "test_runtime")
+        self.assertTrue(RuntimeTrackerMeta.module_imported())
+        self.assertTrue(RuntimeFeatureChecker.runtime_loaded())
+
+    def test_class_imported_from_a_module(self):
+        class TestRuntime1(metaclass=RuntimeTrackerMeta):
+            runtime_name = "fastapi"
+
+        self.assertEqual(RuntimeTrackerMeta.get_module(), __name__)
+        self.assertEqual(RuntimeTrackerMeta.get_runtime_name(), "fastapi")
+        self.assertTrue(RuntimeTrackerMeta.module_imported())
+        self.assertTrue(RuntimeFeatureChecker.runtime_loaded())
+
+    def test_classes_imported_from_different_modules(self):
+        class TestRuntime1(metaclass=RuntimeTrackerMeta):
+            __module__ = "module1"
+            runtime_name = "fastapi"
+
+        self.assertEqual(RuntimeTrackerMeta.get_module(), "module1")
+        self.assertEqual(RuntimeTrackerMeta.get_runtime_name(), "fastapi")
+        self.assertTrue(RuntimeTrackerMeta.module_imported())
+
+        with self.assertRaises(Exception) as context:
+
+            class TestRuntime2(metaclass=RuntimeTrackerMeta):
+                __module__ = "module2"
+                runtime_name = "flask"
+
+        self.assertEqual(
+            str(context.exception),
+            "Only one runtime package shall be imported at a time. "
+            "module1 and module2 are imported.",
+        )
+
+    def test_runtime_name_not_set(self):
+        class TestRuntime(metaclass=RuntimeTrackerMeta):
+            pass
+
+        self.assertEqual(RuntimeTrackerMeta.get_module(), __name__)
+        self.assertIsNone(RuntimeTrackerMeta.get_runtime_name())
+        self.assertTrue(RuntimeTrackerMeta.module_imported())
+
+    def test_multiple_runtimes_same_name(self):
+        class TestRuntime1(metaclass=RuntimeTrackerMeta):
+            runtime_name = "fastapi"
+
+        class TestRuntime2(metaclass=RuntimeTrackerMeta):
+            runtime_name = "fastapi"
+
+        self.assertEqual(RuntimeTrackerMeta.get_module(), __name__)
+        self.assertEqual(RuntimeTrackerMeta.get_runtime_name(), "fastapi")
+        self.assertTrue(RuntimeTrackerMeta.module_imported())
+
+
+class TestRuntimeBase(unittest.TestCase):
+    def test_runtime_base_is_abstract(self):
+        # Ensure RuntimeBase cannot be instantiated directly
+        with self.assertRaises(TypeError):
+            RuntimeBase()
+
+    def test_worker_init_request_raises_not_implemented_error(self):
+        class MockRuntime(RuntimeBase):
+            runtime_name = "mock"
+
+            async def functions_metadata_request(self, request):
+                pass
+
+            async def function_load_request(self, request):
+                pass
+
+            async def invocation_request(self, request):
+                pass
+
+            async def function_environment_reload_request(self, request):
+                pass
+
+            async def worker_init_request(self, request):
+                await super().worker_init_request(request)
+
+        mock_runtime = MockRuntime()
+
+        with self.assertRaises(NotImplementedError):
+            import asyncio
+
+            asyncio.run(mock_runtime.worker_init_request(None))
+
+    def test_functions_metadata_request_raises_not_implemented_error(self):
+        class MockRuntime(RuntimeBase):
+            runtime_name = "mock"
+
+            async def worker_init_request(self, request):
+                pass
+
+            async def function_load_request(self, request):
+                pass
+
+            async def invocation_request(self, request):
+                pass
+
+            async def function_environment_reload_request(self, request):
+                pass
+
+            async def functions_metadata_request(self, request):
+                await super().functions_metadata_request(request)
+
+        mock_runtime = MockRuntime()
+
+        with self.assertRaises(NotImplementedError):
+            import asyncio
+
+            asyncio.run(mock_runtime.functions_metadata_request(None))
+
+    def test_function_load_request_raises_not_implemented_error(self):
+        class MockRuntime(RuntimeBase):
+            runtime_name = "mock"
+
+            async def worker_init_request(self, request):
+                pass
+
+            async def functions_metadata_request(self, request):
+                pass
+
+            async def invocation_request(self, request):
+                pass
+
+            async def function_environment_reload_request(self, request):
+                pass
+
+            async def function_load_request(self, request):
+                await super().function_load_request(request)
+
+        mock_runtime = MockRuntime()
+
+        with self.assertRaises(NotImplementedError):
+            import asyncio
+
+            asyncio.run(mock_runtime.function_load_request(None))
+
+    def test_invocation_request_raises_not_implemented_error(self):
+        class MockRuntime(RuntimeBase):
+            runtime_name = "mock"
+
+            async def worker_init_request(self, request):
+                pass
+
+            async def functions_metadata_request(self, request):
+                pass
+
+            async def function_load_request(self, request):
+                pass
+
+            async def function_environment_reload_request(self, request):
+                pass
+
+            async def invocation_request(self, request):
+                await super().invocation_request(request)
+
+        mock_runtime = MockRuntime()
+
+        with self.assertRaises(NotImplementedError):
+            import asyncio
+
+            asyncio.run(mock_runtime.invocation_request(None))
+
+    def test_function_environment_reload_request_raises_not_implemented_error(self):
+        class MockRuntime(RuntimeBase):
+            runtime_name = "mock"
+
+            async def worker_init_request(self, request):
+                pass
+
+            async def functions_metadata_request(self, request):
+                pass
+
+            async def function_load_request(self, request):
+                pass
+
+            async def invocation_request(self, request):
+                pass
+
+            async def function_environment_reload_request(self, request):
+                await super().function_environment_reload_request(request)
+
+        mock_runtime = MockRuntime()
+
+        with self.assertRaises(NotImplementedError):
+            import asyncio
+
+            asyncio.run(mock_runtime.function_environment_reload_request(None))
+
+    def test_runtime_implementation(self):
+        class TestRuntime(RuntimeBase):
+            runtime_name = "test_runtime"
+
+            async def worker_init_request(self, request):
+                return "worker_init_response"
+
+            async def functions_metadata_request(self, request):
+                return "functions_metadata_response"
+
+            async def function_load_request(self, request):
+                return "function_load_response"
+
+            async def invocation_request(self, request):
+                return "invocation_response"
+
+            async def function_environment_reload_request(self, request):
+                return "function_environment_reload_response"
+
+        runtime = TestRuntime()
+        self.assertEqual(runtime.runtime_name, "test_runtime")
+
+        import asyncio
+
+        self.assertEqual(
+            asyncio.run(runtime.worker_init_request(None)), "worker_init_response"
+        )
+        self.assertEqual(
+            asyncio.run(runtime.functions_metadata_request(None)),
+            "functions_metadata_response",
+        )
+        self.assertEqual(
+            asyncio.run(runtime.function_load_request(None)), "function_load_response"
+        )
+        self.assertEqual(
+            asyncio.run(runtime.invocation_request(None)), "invocation_response"
+        )
+        self.assertEqual(
+            asyncio.run(runtime.function_environment_reload_request(None)),
+            "function_environment_reload_response",
+        )
+
+
+class TestRuntimeFeatureChecker(unittest.TestCase):
+    def setUp(self):
+        # Reset the _module and _runtime_name attributes before each test
+        RuntimeTrackerMeta._module = None
+        RuntimeTrackerMeta._runtime_name = None
+
+    def test_runtime_not_loaded(self):
+        self.assertFalse(RuntimeFeatureChecker.runtime_loaded())
+        self.assertIsNone(RuntimeFeatureChecker.get_runtime_name())
+
+    def test_runtime_loaded(self):
+        class TestRuntime(metaclass=RuntimeTrackerMeta):
+            runtime_name = "fastapi"
+
+        self.assertTrue(RuntimeFeatureChecker.runtime_loaded())
+        self.assertEqual(RuntimeFeatureChecker.get_runtime_name(), "fastapi")
+
+    def test_runtime_loaded_without_name(self):
+        class TestRuntime(metaclass=RuntimeTrackerMeta):
+            pass
+
+        self.assertTrue(RuntimeFeatureChecker.runtime_loaded())
+        self.assertIsNone(RuntimeFeatureChecker.get_runtime_name())
+
+    def test_multiple_runtime_checks(self):
+        # Initially, no runtime should be loaded
+        self.assertFalse(RuntimeFeatureChecker.runtime_loaded())
+
+        class TestRuntime1(metaclass=RuntimeTrackerMeta):
+            runtime_name = "runtime1"
+
+        # After defining the first runtime, it should be loaded
+        self.assertTrue(RuntimeFeatureChecker.runtime_loaded())
+        self.assertEqual(RuntimeFeatureChecker.get_runtime_name(), "runtime1")
+
+        # Define another runtime from the same module
+        class TestRuntime2(metaclass=RuntimeTrackerMeta):
+            runtime_name = "runtime1"
+
+        # The runtime should still be loaded with the same name
+        self.assertTrue(RuntimeFeatureChecker.runtime_loaded())
+        self.assertEqual(RuntimeFeatureChecker.get_runtime_name(), "runtime1")

--- a/azurefunctions-extensions-base/tests/test_runtime.py
+++ b/azurefunctions-extensions-base/tests/test_runtime.py
@@ -77,11 +77,6 @@ class TestRuntimeTrackerMeta(unittest.TestCase):
 
 
 class TestRuntimeBase(unittest.TestCase):
-    def test_runtime_base_is_abstract(self):
-        # Ensure RuntimeBase cannot be instantiated directly
-        with self.assertRaises(TypeError):
-            RuntimeBase()
-
     def test_worker_init_request_raises_not_implemented_error(self):
         class MockRuntime(RuntimeBase):
             runtime_name = "mock"


### PR DESCRIPTION
Runtime Base Class (with Metaclass registration)

This module provides the core abstractions for runtime packages:
- RuntimeTrackerMeta: Metaclass that auto-registers runtimes at import time
- RuntimeBase: Abstract base class that all runtimes must extend
- RuntimeFeatureChecker: Utility to check if a runtime is loaded