### PR TITLE
feat: support ClientReceiveMessage SDK-type bindings

### DIFF
--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/meta.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/meta.py
@@ -125,6 +125,40 @@ class _ConverterMeta(abc.ABCMeta):
         return (isinstance(inner_type, type)
                 and issubclass(inner_type, sdkType.SdkType))
 
+    @classmethod
+    def get_sdk_type_class(cls, annotation: type) -> Optional[type]:
+        """Extract the SdkType class from an annotation.
+        
+        Handles both direct SdkType annotations and iterable types
+        like List[SdkType].
+        
+        Args:
+            annotation: The type annotation to extract from.
+            
+        Returns:
+            The SdkType class if found, None otherwise.
+        """
+        if annotation is None:
+            return None
+
+        # Direct SdkType subclass
+        if (isinstance(annotation, type)
+                and issubclass(annotation, sdkType.SdkType)):
+            return annotation
+
+        # Check for iterable with SdkType inner type
+        base_type = get_origin(annotation)
+        if (base_type is not None
+                and issubclass(base_type, collections.abc.Iterable)):
+            inner_types = get_args(annotation)
+            if inner_types and len(inner_types) == 1:
+                inner_type = inner_types[0]
+                if (isinstance(inner_type, type)
+                        and issubclass(inner_type, sdkType.SdkType)):
+                    return inner_type
+
+        return None
+
     def has_trigger_support(cls) -> bool:
         return cls._trigger is not None  # type: ignore
 

--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/meta.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/meta.py
@@ -128,13 +128,13 @@ class _ConverterMeta(abc.ABCMeta):
     @classmethod
     def get_sdk_type_class(cls, annotation: type) -> Optional[type]:
         """Extract the SdkType class from an annotation.
-        
+
         Handles both direct SdkType annotations and iterable types
         like List[SdkType].
-        
+
         Args:
             annotation: The type annotation to extract from.
-            
+
         Returns:
             The SdkType class if found, None otherwise.
         """

--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/sdkType.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/sdkType.py
@@ -11,10 +11,10 @@ class SdkType:
     @classmethod
     def supports_deferred_binding(cls) -> bool:
         """Returns whether this SDK type supports deferred binding.
-        
+
         Override this method in subclasses to return False if the extension
         should not use deferred binding (SupportsDeferredBinding flag = False).
-        
+
         Returns:
             True by default. Override to return False to disable deferred binding.
         """

--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/sdkType.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/sdkType.py
@@ -8,6 +8,18 @@ class SdkType:
     def __init__(self, *, data: dict = None):
         self._data = data or {}
 
+    @classmethod
+    def supports_deferred_binding(cls) -> bool:
+        """Returns whether this SDK type supports deferred binding.
+        
+        Override this method in subclasses to return False if the extension
+        should not use deferred binding (SupportsDeferredBinding flag = False).
+        
+        Returns:
+            True by default. Override to return False to disable deferred binding.
+        """
+        return True
+
     @abstractmethod
     def get_sdk_type(self):
         pass

--- a/azurefunctions-extensions-base/azurefunctions/extensions/base/utils.py
+++ b/azurefunctions-extensions-base/azurefunctions/extensions/base/utils.py
@@ -185,10 +185,18 @@ class Binding(ABC):
         # 1. check if the binding is a supported type (blob, blobTrigger)
         # 2. check if the binding is an input binding
         # 3. check if the defined type is an SdkType
+        # 4. check if the SdkType supports deferred binding
+        is_supported_type = meta._ConverterMeta.check_supported_type(pytype)
+        sdk_type_class = meta._ConverterMeta.get_sdk_type_class(pytype)
+        supports_deferred = (
+            sdk_type_class is not None
+            and sdk_type_class.supports_deferred_binding()
+        )
         if (
             binding.type in meta._ConverterMeta._bindings
             and binding.direction == 0
-            and meta._ConverterMeta.check_supported_type(pytype)
+            and is_supported_type
+            and supports_deferred
         ):
             binding._dict["properties"] = {"SupportsDeferredBinding": True}
             binding_info = {binding.name: {pytype: "True"}}

--- a/azurefunctions-extensions-base/tests/test_sdk_type.py
+++ b/azurefunctions-extensions-base/tests/test_sdk_type.py
@@ -20,3 +20,33 @@ class TestSdkType(unittest.TestCase):
 
         mock_type = MockSdkType()
         self.assertIsNone(mock_type.get_sdk_type())
+
+    def test_supports_deferred_binding_default_true(self):
+        """Test that SdkType.supports_deferred_binding returns True by default."""
+        self.assertTrue(sdkType.SdkType.supports_deferred_binding())
+
+    def test_supports_deferred_binding_inherited(self):
+        """Test that subclasses inherit the default True value."""
+        class MockSdkType(sdkType.SdkType):
+            def get_sdk_type(self):
+                return None
+
+        self.assertTrue(MockSdkType.supports_deferred_binding())
+        # Also test on instance
+        instance = MockSdkType()
+        self.assertTrue(instance.supports_deferred_binding())
+
+    def test_supports_deferred_binding_override_false(self):
+        """Test that subclasses can override to return False."""
+        class MockSdkTypeNoDeferred(sdkType.SdkType):
+            @classmethod
+            def supports_deferred_binding(cls) -> bool:
+                return False
+
+            def get_sdk_type(self):
+                return None
+
+        self.assertFalse(MockSdkTypeNoDeferred.supports_deferred_binding())
+        # Also test on instance
+        instance = MockSdkTypeNoDeferred()
+        self.assertFalse(instance.supports_deferred_binding())

--- a/azurefunctions-extensions-connectors-office365/CHANGELOG.md
+++ b/azurefunctions-extensions-connectors-office365/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0b1] - 2026-05-11
+
+### Added
+- Initial beta release of azurefunctions-extensions-connectors-office365
+- Support for Office365 Connector Triggers
+- ClientReceiveMessage type support for single message processing
+- List[ClientReceiveMessage] type support for batch message processing
+- Integration with azure-connectors SDK
+- Support for both model_binding_data and collection_model_binding_data cardinalities

--- a/azurefunctions-extensions-connectors-office365/LICENSE
+++ b/azurefunctions-extensions-connectors-office365/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/azurefunctions-extensions-connectors-office365/MANIFEST.in
+++ b/azurefunctions-extensions-connectors-office365/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include azurefunctions *.py *.pyi
+recursive-include tests *.py
+include LICENSE README.md

--- a/azurefunctions-extensions-connectors-office365/README.md
+++ b/azurefunctions-extensions-connectors-office365/README.md
@@ -1,0 +1,102 @@
+# Azure Functions Extensions Connectors Office365 library for Python
+
+This library allows Office365 Connector Triggers in Python Function Apps to recognize and bind to client types from the Azure Connectors SDK.
+
+Office365 client types can be generated from:
+
+* Office365 Connector Triggers
+
+[Source code](https://github.com/Azure/azure-functions-python-extensions/tree/dev/azurefunctions-extensions-connectors-office365)
+| [Package (PyPi)](https://pypi.org/project/azurefunctions-extensions-connectors-office365/)
+| API reference documentation
+| Product documentation
+| [Samples](https://github.com/Azure/azure-functions-python-extensions/tree/dev/azurefunctions-extensions-connectors-office365/samples)
+
+
+## Getting started
+
+### Prerequisites
+* Python 3.9 or later is required to use this package. For more details, please read our page on [Python Functions version support policy](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=isolated-process%2Cv4&pivots=programming-language-python#languages).
+
+* You must have an [Azure subscription](https://azure.microsoft.com/free/) and an Office365 account to use this package.
+
+### Install the package
+Install the Azure Functions Extensions Connectors Office365 library for Python with pip:
+
+```bash
+pip install azurefunctions-extensions-connectors-office365
+```
+
+### Bind to the SDK-type
+The Azure Functions Extensions Connectors Office365 library for Python allows you to create a function app with an Office365 Connector Trigger and define the type as a ClientReceiveMessage or List[ClientReceiveMessage]. Instead of receiving raw data, when the function is executed, the type returned will be the defined SDK-type and have all of the methods available from the `azure-connectors` SDK.
+
+## Key concepts
+
+### ClientReceiveMessage
+The `ClientReceiveMessage` type represents a message received from an Office365 connector. The extension automatically parses the incoming JSON payload and converts it into typed ClientReceiveMessage objects from the `azure-connectors` SDK.
+
+### Cardinality
+Office365 Connector Triggers support both single and batch message processing:
+
+* **Single message (cardinality=one)**: Annotate your function parameter as `ClientReceiveMessage` to receive one message per function invocation
+* **Batch messages (cardinality=many)**: Annotate your function parameter as `List[ClientReceiveMessage]` to receive multiple messages in a single function invocation
+
+## Examples
+
+### Office365 Connector Trigger - Single Message
+
+```python
+import logging
+import azure.functions as func
+import azurefunctions.extensions.connectors.office365 as office365
+
+app = func.FunctionApp()
+
+@app.connector_trigger(arg_name="message", connection="OFFICE365_CONNECTION")
+def office365_trigger_single(message: office365.ClientReceiveMessage):
+    logging.info(f"Received Office365 message: {message}")
+    # Access message properties using the Azure Connectors SDK methods
+```
+
+### Office365 Connector Trigger - Batch Messages
+
+```python
+import logging
+from typing import List
+import azure.functions as func
+import azurefunctions.extensions.connectors.office365 as office365
+
+app = func.FunctionApp()
+
+@app.connector_trigger(arg_name="messages", connection="OFFICE365_CONNECTION")
+def office365_trigger_batch(messages: List[office365.ClientReceiveMessage]):
+    logging.info(f"Received {len(messages)} Office365 messages")
+    for message in messages:
+        logging.info(f"Processing message: {message}")
+        # Access message properties using the Azure Connectors SDK methods
+```
+
+## Troubleshooting
+
+### General
+Office365 Connector extension errors will be raised as `ValueError` exceptions with descriptive error messages.
+
+### Logging
+Enable verbose logging in your function app to see detailed information about message processing:
+
+```python
+import logging
+logging.basicConfig(level=logging.INFO)
+```
+
+## Next steps
+
+### More sample code
+Get started with our [Office365 Connector samples](https://github.com/Azure/azure-functions-python-extensions/tree/dev/azurefunctions-extensions-connectors-office365/samples).
+
+## Contributing
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/azurefunctions-extensions-connectors-office365/azurefunctions/__init__.py
+++ b/azurefunctions-extensions-connectors-office365/azurefunctions/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/azurefunctions-extensions-connectors-office365/azurefunctions/extensions/__init__.py
+++ b/azurefunctions-extensions-connectors-office365/azurefunctions/extensions/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/azurefunctions-extensions-connectors-office365/azurefunctions/extensions/connectors/__init__.py
+++ b/azurefunctions-extensions-connectors-office365/azurefunctions/extensions/connectors/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/azurefunctions-extensions-connectors-office365/azurefunctions/extensions/connectors/office365/__init__.py
+++ b/azurefunctions-extensions-connectors-office365/azurefunctions/extensions/connectors/office365/__init__.py
@@ -1,0 +1,12 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License.
+
+from .clientReceiveMessage import ClientReceiveMessage
+from .clientReceiveMessageConverter import ClientReceiveMessageConverter
+
+__all__ = [
+    "ClientReceiveMessage",
+    "ClientReceiveMessageConverter",
+]
+
+__version__ = '1.0.0b1'

--- a/azurefunctions-extensions-connectors-office365/azurefunctions/extensions/connectors/office365/clientReceiveMessage.py
+++ b/azurefunctions-extensions-connectors-office365/azurefunctions/extensions/connectors/office365/clientReceiveMessage.py
@@ -1,0 +1,41 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License.
+
+from typing import List
+
+from azure.connectors.office365 import ClientReceiveMessage as AzureClientReceiveMessage
+from azurefunctions.extensions.base import Datum, SdkType
+
+
+class ClientReceiveMessage(SdkType, AzureClientReceiveMessage):
+    def __init__(self, *, data: Datum) -> None:
+        self._json_payload = data
+
+    @classmethod
+    def supports_deferred_binding(cls) -> bool:
+        """Office365 connector does not support deferred binding."""
+        return False
+
+    def get_sdk_type(self) -> List[AzureClientReceiveMessage]:
+        """
+        Uses the from_json method to parse the JSON payload into a list of
+        ClientReceiveMessage objects.
+        
+        Returns:
+            List of ClientReceiveMessage objects parsed from the JSON payload.
+        """
+        if not self._json_payload:
+            raise ValueError(
+                f"Unable to create {self.__class__.__name__} SDK type. "
+                f"No data provided."
+            )
+        
+        try:
+            # Use the Azure SDK's from_json method to parse the payload
+            messages = AzureClientReceiveMessage.from_json(self._json_payload)
+            return messages
+        except Exception as e:
+            raise ValueError(
+                f"Unable to create {self.__class__.__name__} SDK type. "
+                f"Exception: {e}"
+            ) from e

--- a/azurefunctions-extensions-connectors-office365/azurefunctions/extensions/connectors/office365/clientReceiveMessageConverter.py
+++ b/azurefunctions-extensions-connectors-office365/azurefunctions/extensions/connectors/office365/clientReceiveMessageConverter.py
@@ -1,0 +1,68 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License.
+
+import collections.abc
+from typing import Any, Optional, get_args, get_origin
+
+from azurefunctions.extensions.base import Datum, InConverter
+from .clientReceiveMessage import ClientReceiveMessage
+
+
+class ClientReceiveMessageConverter(
+    InConverter,
+    binding='connectorTrigger', trigger=True
+):
+    @classmethod
+    def check_input_type_annotation(cls, pytype: type) -> bool:
+        if pytype is None:
+            return False
+
+        # The annotation is a class/type (not an object) - not iterable
+        if (isinstance(pytype, type)
+                and issubclass(pytype, ClientReceiveMessage)):
+            return True
+
+        # An iterable who only has one inner type and is a subclass of ClientReceiveMessage
+        return cls._is_iterable_supported_type(pytype)
+
+    @classmethod
+    def _is_iterable_supported_type(cls, annotation: type) -> bool:
+        # Check base type from type hint. Ex: List from List[ClientReceiveMessage]
+        base_type = get_origin(annotation)
+        if (base_type is None
+                or not issubclass(base_type, collections.abc.Iterable)):
+            return False
+
+        inner_types = get_args(annotation)
+        if inner_types is None or len(inner_types) != 1:
+            return False
+
+        inner_type = inner_types[0]
+
+        return (isinstance(inner_type, type)
+                and issubclass(inner_type, ClientReceiveMessage))
+
+    @classmethod
+    def decode(cls, data: Datum, *, trigger_metadata, pytype) -> Optional[Any]:
+        """
+        Office365 Connector allows for batches. This means the cardinality can be one or many.
+        When the cardinality is one:
+            - The data is of type "model_binding_data" - each message is an independent
+              function invocation
+            - Return a single ClientReceiveMessage object
+        When the cardinality is many:
+            - The data is of type "collection_model_binding_data" - all messages are sent
+              in a single function invocation
+            - collection_model_binding_data has 1 or more model_binding_data objects
+            - Return a list of ClientReceiveMessage objects
+        """
+        if data is None or data.type is None:
+            return None
+
+        try:
+            return ClientReceiveMessage(data=data).get_sdk_type()
+        except Exception as e:
+            raise ValueError(
+                "Failed to decode incoming Office365 Connector batch: "
+                + repr(e)
+            ) from e

--- a/azurefunctions-extensions-connectors-office365/pyproject.toml
+++ b/azurefunctions-extensions-connectors-office365/pyproject.toml
@@ -25,7 +25,7 @@ classifiers= [
         'Development Status :: 3 - Alpha',
     ]
 dependencies = [
-    'azurefunctions-extensions-base>=1.3.0',
+    'azurefunctions-extensions-base>=1.3.0b1',
     'azure-connectors>=0.2.0b1'
     ]
 

--- a/azurefunctions-extensions-connectors-office365/pyproject.toml
+++ b/azurefunctions-extensions-connectors-office365/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "azurefunctions-extensions-connectors-office365"
+name = "azurefunctions-extensions-connectors"
 dynamic = ["version"]
 requires-python = ">=3.10"
 authors = [{ name = "Azure Functions team at Microsoft Corp.", email = "azurefunctions@microsoft.com"}]
@@ -45,6 +45,6 @@ version = {attr = "azurefunctions.extensions.connectors.office365.__version__"}
 
 [tool.setuptools.packages.find]
 exclude = [
-    'azurefunctions.extensions.connectors','azurefunctions.extensions',
+    'azurefunctions.extensions',
     'azurefunctions', 'tests', 'samples'
     ]

--- a/azurefunctions-extensions-connectors-office365/pyproject.toml
+++ b/azurefunctions-extensions-connectors-office365/pyproject.toml
@@ -25,8 +25,8 @@ classifiers= [
         'Development Status :: 3 - Alpha',
     ]
 dependencies = [
-    'azurefunctions-extensions-base',
-    'azure-connectors'
+    'azurefunctions-extensions-base>=1.3.0',
+    'azure-connectors>=0.2.0b1'
     ]
 
 [project.optional-dependencies]

--- a/azurefunctions-extensions-connectors-office365/pyproject.toml
+++ b/azurefunctions-extensions-connectors-office365/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "azurefunctions-extensions-connectors-office365"
+dynamic = ["version"]
+requires-python = ">=3.10"
+authors = [{ name = "Azure Functions team at Microsoft Corp.", email = "azurefunctions@microsoft.com"}]
+description = "Office365 Connector Python worker extension for Azure Functions."
+readme = "README.md"
+license = {text = "MIT License"}
+classifiers= [
+        'License :: OSI Approved :: MIT License',
+        'Intended Audience :: Developers',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX',
+        'Operating System :: MacOS :: MacOS X',
+        'Environment :: Web Environment',
+        'Development Status :: 3 - Alpha',
+    ]
+dependencies = [
+    'azurefunctions-extensions-base',
+    'azure-connectors'
+    ]
+
+[project.optional-dependencies]
+dev = [
+    'flake8',
+    'mypy',
+    'pytest',
+    'pytest-cov',
+    'coverage',
+    'pytest-instafail',
+    'pre-commit'
+    ]
+
+[tool.setuptools.dynamic]
+version = {attr = "azurefunctions.extensions.connectors.office365.__version__"}
+
+[tool.setuptools.packages.find]
+exclude = [
+    'azurefunctions.extensions.connectors','azurefunctions.extensions',
+    'azurefunctions', 'tests', 'samples'
+    ]

--- a/azurefunctions-extensions-connectors-office365/tests/__init__.py
+++ b/azurefunctions-extensions-connectors-office365/tests/__init__.py
@@ -1,0 +1,2 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License.

--- a/azurefunctions-extensions-connectors-office365/tests/test_clientreceivemessage.py
+++ b/azurefunctions-extensions-connectors-office365/tests/test_clientreceivemessage.py
@@ -1,0 +1,41 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License.
+
+import unittest
+from typing import List
+
+from azurefunctions.extensions.connectors.office365 import (
+    ClientReceiveMessage,
+    ClientReceiveMessageConverter
+)
+
+
+class TestClientReceiveMessageConverter(unittest.TestCase):
+    def test_input_type_single(self):
+        """Test that ClientReceiveMessage type annotation is accepted"""
+        check_input_type = ClientReceiveMessageConverter.check_input_type_annotation
+        self.assertTrue(check_input_type(ClientReceiveMessage))
+
+    def test_input_type_list(self):
+        """Test that List[ClientReceiveMessage] type annotation is accepted"""
+        check_input_type = ClientReceiveMessageConverter.check_input_type_annotation
+        self.assertTrue(check_input_type(List[ClientReceiveMessage]))
+
+    def test_input_type_invalid(self):
+        """Test that invalid type annotations are rejected"""
+        check_input_type = ClientReceiveMessageConverter.check_input_type_annotation
+        self.assertFalse(check_input_type(str))
+        self.assertFalse(check_input_type(bytes))
+        self.assertFalse(check_input_type(dict))
+        self.assertFalse(check_input_type(List[str]))
+
+    def test_input_none(self):
+        """Test that None data returns None"""
+        result = ClientReceiveMessageConverter.decode(
+            data=None, trigger_metadata=None, pytype=ClientReceiveMessage
+        )
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/azurefunctions-extensions-connectors-office365/tests/test_code_quality.py
+++ b/azurefunctions-extensions-connectors-office365/tests/test_code_quality.py
@@ -1,0 +1,41 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License.
+
+import os
+import subprocess
+import sys
+import unittest
+
+
+class TestCodeQuality(unittest.TestCase):
+    def test_flake8(self):
+        """Run flake8 on the package"""
+        package_dir = os.path.join(
+            os.path.dirname(__file__),
+            '..',
+            'azurefunctions'
+        )
+        result = subprocess.run(
+            [sys.executable, '-m', 'flake8', package_dir],
+            capture_output=True
+        )
+        if result.returncode != 0:
+            self.fail(f"flake8 found issues:\n{result.stdout.decode()}")
+
+    def test_mypy(self):
+        """Run mypy on the package"""
+        package_dir = os.path.join(
+            os.path.dirname(__file__),
+            '..',
+            'azurefunctions'
+        )
+        result = subprocess.run(
+            [sys.executable, '-m', 'mypy', package_dir, '--ignore-missing-imports'],
+            capture_output=True
+        )
+        if result.returncode != 0:
+            print(f"mypy output:\n{result.stdout.decode()}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds support for binding to the `azure-connectors` `ClientReceiveMessage` SDK type.

Updates base extension to allow supporting SDK-type only bindings (not deferred bindings).