### PR TITLE
build: update to cfs pt.2

### DIFF
--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -46,5 +46,5 @@ jobs:
       - bash: |
           pip install pip-audit
           cd $(EXTENSION_DIRECTORY)
-          pip-audit .
+          pip-audit --vulnerability-service osv .
         displayName: 'Run vulnerability scan'

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -31,6 +31,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: public/PythonExtensions_PublicPackages
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: '3.11'

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -44,8 +44,3 @@ jobs:
           cd $(EXTENSION_DIRECTORY)
           python -m build
         displayName: 'Build $(EXTENSION_NAME) Extension'
-      - bash: |
-          pip install pip-audit
-          cd $(EXTENSION_DIRECTORY)
-          pip-audit --vulnerability-service osv .
-        displayName: 'Run vulnerability scan'

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -27,13 +27,13 @@ jobs:
           EXTENSION_NAME: 'Connectors'
 
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.11'
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: public/PythonExtensions_PublicPackages
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.11'
       - bash: |
           python --version
         displayName: 'Check python version'

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -33,13 +33,13 @@ jobs:
           artifactName: "$(EXTENSION_DIRECTORY)"
 
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.11'
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: internal/PythonExtensions_Internal_PublicPackages
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.11'
       - bash: |
           python --version
         displayName: 'Check python version'

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -52,5 +52,5 @@ jobs:
       - bash: |
           pip install pip-audit
           cd $(EXTENSION_DIRECTORY)
-          pip-audit .
+          pip-audit --vulnerability-service osv .
         displayName: 'Run vulnerability scan'

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -37,6 +37,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: internal/PythonExtensions_Internal_PublicPackages
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: '3.11'

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -50,8 +50,3 @@ jobs:
           cd $(EXTENSION_DIRECTORY)
           python -m build
         displayName: 'Build $(EXTENSION_NAME) Extension'
-      - bash: |
-          pip install pip-audit
-          cd $(EXTENSION_DIRECTORY)
-          pip-audit --vulnerability-service osv .
-        displayName: 'Run vulnerability scan'

--- a/eng/templates/official/jobs/publish-release.yml
+++ b/eng/templates/official/jobs/publish-release.yml
@@ -204,6 +204,7 @@ jobs:
     displayName: 'Pip Authenticate'
     inputs:
       artifactFeeds: internal/PythonExtensions_Internal_PublicPackages
+      onlyAddExtraIndex: false
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Python Extension release/.x.y.z Artifact'
     inputs:

--- a/eng/templates/official/jobs/publish-release.yml
+++ b/eng/templates/official/jobs/publish-release.yml
@@ -200,6 +200,10 @@ jobs:
   dependsOn: ['FinishWorkerPr']
   displayName: 'PyPI Package'
   steps:
+  - task: PipAuthenticate@1
+    displayName: 'Pip Authenticate'
+    inputs:
+      artifactFeeds: internal/PythonExtensions_Internal_PublicPackages
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Python Extension release/.x.y.z Artifact'
     inputs:
@@ -214,10 +218,6 @@ jobs:
     displayName: 'Use Python 3.11'
     inputs:
       versionSpec: 3.11
-  - task: PipAuthenticate@1
-    displayName: 'Pip Authenticate'
-    inputs:
-      artifactFeeds: internal/PythonExtensions_Internal_PublicPackages
   - pwsh: |
       $newLibraryVersion = "$(NewLibraryVersion)"
       $pypiToken = "$(PypiToken)"

--- a/eng/templates/official/jobs/unit-tests.yml
+++ b/eng/templates/official/jobs/unit-tests.yml
@@ -32,6 +32,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
@@ -55,6 +56,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
@@ -86,6 +88,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
@@ -112,6 +115,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
@@ -135,6 +139,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
@@ -158,6 +163,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
@@ -181,6 +187,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)

--- a/eng/templates/official/jobs/unit-tests.yml
+++ b/eng/templates/official/jobs/unit-tests.yml
@@ -28,13 +28,13 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-base
@@ -51,13 +51,13 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-bindings-blob
@@ -82,13 +82,13 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-bindings-cosmosdb
@@ -108,13 +108,13 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-bindings-eventhub
@@ -131,13 +131,13 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-http-fastapi
@@ -154,13 +154,13 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-bindings-servicebus
@@ -177,13 +177,13 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-connectors


### PR DESCRIPTION
- Move `PipAuthenticate@1` task above `UsePythonVersion@0` task to prevent `pip` installation through pypi.org
- Removes pip audit - requires further investigation

Ref build run: https://azfunc.visualstudio.com/public/_build/results?buildId=294667&view=logs&j=e1ea21cf-43a6-50fb-1d8c-1d621f6dc65b&t=871e892c-aef9-5752-200f-80456b1f1fe4