### PR TITLE
build: route Python restores through CFS

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -49,4 +49,3 @@ extends:
           - template: /eng/templates/official/jobs/unit-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: internal/PythonExtensions_Internal_PublicPackages

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -49,4 +49,3 @@ extends:
           - template: /eng/templates/official/jobs/unit-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc-public
-              ArtifactFeed: public/PythonExtensions_PublicPackages

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -27,13 +27,14 @@ jobs:
           EXTENSION_NAME: 'Connectors'
 
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.11'
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: public/PythonExtensions_PublicPackages
+          artifactFeeds: public/upstream-public
+          onlyAddExtraIndex: false
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.11'
       - bash: |
           python --version
         displayName: 'Check python version'

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -33,13 +33,14 @@ jobs:
           artifactName: "$(EXTENSION_DIRECTORY)"
 
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.11'
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: internal/PythonExtensions_Internal_PublicPackages
+          artifactFeeds: public/upstream-public
+          onlyAddExtraIndex: false
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.11'
       - bash: |
           python --version
         displayName: 'Check python version'

--- a/eng/templates/official/jobs/publish-release.yml
+++ b/eng/templates/official/jobs/publish-release.yml
@@ -210,14 +210,15 @@ jobs:
       buildVersionToDownload: latestFromBranch
       branchName: refs/heads/dev
       targetPath: PythonExtensionArtifact
+  - task: PipAuthenticate@1
+    displayName: 'Pip Authenticate'
+    inputs:
+      artifactFeeds: public/upstream-public
+      onlyAddExtraIndex: false
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.11'
     inputs:
       versionSpec: 3.11
-  - task: PipAuthenticate@1
-    displayName: 'Pip Authenticate'
-    inputs:
-      artifactFeeds: internal/PythonExtensions_Internal_PublicPackages
   - pwsh: |
       $newLibraryVersion = "$(NewLibraryVersion)"
       $pypiToken = "$(PypiToken)"

--- a/eng/templates/official/jobs/unit-tests.yml
+++ b/eng/templates/official/jobs/unit-tests.yml
@@ -2,9 +2,6 @@ parameters:
   - name: PoolName
     type: string
     default: ''
-  - name: ArtifactFeed
-    type: string
-    default: ''
   - name: python_versions
     type: object
     default:
@@ -28,13 +25,14 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: public/upstream-public
+          onlyAddExtraIndex: false
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-base
@@ -51,13 +49,14 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: public/upstream-public
+          onlyAddExtraIndex: false
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-bindings-blob
@@ -82,13 +81,14 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: public/upstream-public
+          onlyAddExtraIndex: false
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-bindings-cosmosdb
@@ -108,13 +108,14 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: public/upstream-public
+          onlyAddExtraIndex: false
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-bindings-eventhub
@@ -131,13 +132,14 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: public/upstream-public
+          onlyAddExtraIndex: false
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-http-fastapi
@@ -154,13 +156,14 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: public/upstream-public
+          onlyAddExtraIndex: false
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-bindings-servicebus
@@ -177,13 +180,14 @@ jobs:
       matrix: ${{ parameters.python_versions }}
     condition: always()
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: public/upstream-public
+          onlyAddExtraIndex: false
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           python -m pip install --upgrade pip
           cd azurefunctions-extensions-connectors


### PR DESCRIPTION
## Summary

- Route every repository-owned Azure Pipelines Python install job through `azfunc/public/upstream-public`.
- Run `PipAuthenticate@1` before `UsePythonVersion@0` and explicitly replace the primary index with `onlyAddExtraIndex: false`.
- Remove the legacy per-pipeline feed parameter and old `PythonExtensions_*PublicPackages` feed references.
- Leave customer samples, requirements files, release upload destinations, and dependency manifests unchanged; no pip configuration is committed.

EM owner: @vameru

## Validation

- Parsed all 13 YAML files and structurally verified all 10 Python-installing jobs have exactly one correctly configured authentication task before Python setup and package installation.
- Resolved all seven package development/runtime graphs from empty caches through CFS in a checkout path containing spaces, using structured command arguments.
- Recorded 716 CFS resolver-host matches and zero direct requests to `pypi.org`, `files.pythonhosted.org`, npmjs, or nuget.org across 32 resolver logs.
- Passed 314 tests across base, Blob, Cosmos DB, Event Hubs, Service Bus, FastAPI, and Connectors. Three Blob downloader tests requiring live Azure Storage were deselected locally.
- Downloaded complete binary graphs from empty caches for CPython 3.9 and 3.13 on Windows, Linux, and macOS (62/73 files per platform), plus the CPython 3.11 Windows build/audit tool graph (44 files).
- Built and checked seven wheels plus seven source distributions; smoke-installed and imported all seven wheels; all seven `pip-audit` runs reported no known vulnerabilities.
- Audited archives and the worktree: no feed configuration, credentials, lockfiles, `node_modules`, committed pip config, or manifest rewrites were introduced.

## Surface audit

The repository owns Python packaging and Azure Pipelines install surfaces. It has no repository-owned npm project, NuGet/.NET project, uv usage, or Dockerfile requiring CFS changes. GitHub Actions contains only a PR-title check and performs no package installation.