### PR TITLE
build: remove pip audit

### DIFF
--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -44,8 +44,3 @@ jobs:
           cd $(EXTENSION_DIRECTORY)
           python -m build
         displayName: 'Build $(EXTENSION_NAME) Extension'
-      - bash: |
-          pip install pip-audit
-          cd $(EXTENSION_DIRECTORY)
-          pip-audit .
-        displayName: 'Run vulnerability scan'

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -50,8 +50,3 @@ jobs:
           cd $(EXTENSION_DIRECTORY)
           python -m build
         displayName: 'Build $(EXTENSION_NAME) Extension'
-      - bash: |
-          pip install pip-audit
-          cd $(EXTENSION_DIRECTORY)
-          pip-audit .
-        displayName: 'Run vulnerability scan'


### PR DESCRIPTION
Remove `pip-audit .` call from all pipelines to reach CFS compliancy.

Example run: https://azfunc.visualstudio.com/public/_build/results?buildId=295333&view=logs&jobId=57c69fe3-cded-53a4-5271-790d1391d556&j=57c69fe3-cded-53a4-5271-790d1391d556&t=39924112-575f-5fa7-a27e-c1065d3ae6b3