### PR TITLE
chore: fix blob, servicebus samples

### DIFF
--- a/azurefunctions-extensions-bindings-blob/samples/blob_samples_containerclient/function_app.py
+++ b/azurefunctions-extensions-bindings-blob/samples/blob_samples_containerclient/function_app.py
@@ -36,7 +36,7 @@ def blob_trigger(client: blob.ContainerClient):
 
 @app.route(route="file")
 @app.blob_input(arg_name="client", path="CONTAINER", connection="AzureWebJobsStorage")
-def blob_input(req: func.HttpRequest, client: blob.BlobClient):
+def blob_input(req: func.HttpRequest, client: blob.ContainerClient):
     logging.info(
         f"Python blob input function processed blob \n"
         f"Properties: {client.get_container_properties()}\n"

--- a/azurefunctions-extensions-bindings-servicebus/samples/README.md
+++ b/azurefunctions-extensions-bindings-servicebus/samples/README.md
@@ -26,7 +26,7 @@ examples on how to use the Azure ServiceBus client library, please see [Azure Se
 
 
 ## Prerequisites
-* Python 3.9 or later is required to use this package. For more details, please read our page on [Python Functions version support policy](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=isolated-process%2Cv4&pivots=programming-language-python#languages).
+* Python 3.9 through 3.13 is required to use these samples. Python 3.14 is not currently supported because `uamqp` does not publish Python 3.14 wheels. For more details, please read our page on [Python Functions version support policy](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=isolated-process%2Cv4&pivots=programming-language-python#languages).
 
 ## Setup
 

--- a/azurefunctions-extensions-bindings-servicebus/samples/servicebus_samples_settlement/local.settings.json
+++ b/azurefunctions-extensions-bindings-servicebus/samples/servicebus_samples_settlement/local.settings.json
@@ -2,6 +2,7 @@
   "IsEncrypted": false,
   "Values": {
     "FUNCTIONS_WORKER_RUNTIME": "python",
+    "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "QUEUE_NAME": "",
     "SERVICEBUS_CONNECTION": ""


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-functions-python-extensions/issues/168, https://github.com/Azure/azure-functions-python-extensions/issues/169

- Fixes incorrect type hint for blob `ContainerClient` sample
- Add PIWD for ServiceBus samples to fix < 3.12 incompatibility with protobuf
- Document 3.14 limitation for ServiceBus